### PR TITLE
issue#24 prevent converting kitId to Number

### DIFF
--- a/app/api/rallies/route.ts
+++ b/app/api/rallies/route.ts
@@ -28,7 +28,7 @@ export async function POST(request: Request) {
         title,
         description,
         status: 'active',
-        kitId: +kitId,
+        kitId,
         starterId,
         stampCount: 0,
       },


### PR DESCRIPTION
## 작업 내용

관련 이슈: #19 
[Kit의 id가 문자열로 변경되면서](https://github.com/ZZIPSA/kkuk-kkuk-fe/pull/19/commits/431af383e8b674be813676b21694731d9ac65043) `@/app/api/rallies/route.ts:31`의 [kitId를 숫자형으로 변환하는 과정](https://github.com/ZZIPSA/kkuk-kkuk-fe/blob/5d6727d04823b0e5d0e718bd0e1e9e9a9c43d090/app/api/rallies/route.ts#L31)을 제거합니다.

## 테스트 내용

- [x] `next build` 시에 해당 라인에서 문제가 발생하지 않습니다.

### 리뷰어에게

리뷰는 생략하겠습니다.

### 체크리스트

- [x] 셀프 리뷰를 진행했습니다.
- [x] 커밋 메세지를 컨벤션에 맞게 작성했습니다.
- [x] 테스트 내용에 기재된 항목에 대해서 실제로 테스트를 진행하고 동작을 확인했습니다.
