### PR TITLE
issue/#20 refactor:  타입 정리

### DIFF
--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -4,10 +4,10 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { NavigationMenu, NavigationMenuItem, NavigationMenuList } from '@/components/ui/navigation-menu';
 // import { auth } from "@/auth";
-import { User } from '@prisma/client';
 import { getHeaderUserMenuItems, headerLogoItems } from '../lib';
+import { UserModel } from '@/types/models';
 
-type DefaultUser = Pick<User, 'profileImage'>; // 테스트용
+type DefaultUser = Pick<UserModel, 'profileImage'>; // 테스트용
 const defaultUser: DefaultUser = { profileImage: '/default-profile.svg' }; // 테스트용
 
 export default function NavBar() {

--- a/app/kits/components/KitCard.tsx
+++ b/app/kits/components/KitCard.tsx
@@ -5,15 +5,9 @@ import { cn } from '@/lib/utils';
 import { DEFAULT_PROFILE } from '@/lib/constants';
 import { Tag } from '@/stories/Tag';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { KitCardInfo } from '@/types/kit';
+import { KitCardInfo } from '@/types/Kit';
 
-interface KitCardProps extends KitCardInfo, React.ComponentPropsWithoutRef<typeof Card> {
-  id: string;
-  title: string;
-  thumbnailImage: string | null;
-  tags: string[];
-  uploader: { nickname: string | null; profileImage: string | null } | null;
-}
+type KitCardProps = KitCardInfo & React.HTMLAttributes<HTMLDivElement>;
 
 export default function KitCard({ id, title, thumbnailImage, tags, uploader, className, ...props }: KitCardProps) {
   const profileImage = uploader?.profileImage ?? DEFAULT_PROFILE;

--- a/app/kits/page.tsx
+++ b/app/kits/page.tsx
@@ -1,9 +1,24 @@
-import { kitCardSelect, prisma } from '@/lib/prisma';
 import KitCard from './components/KitCard';
-import { KitCardsInfo } from '@/types/kit';
+import { KitCardsInfo } from '@/types/Kit';
+
+async function fetchKits(): Promise<KitCardsInfo> {
+  const response = await fetch('http://localhost:3000/api/kits', {
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch kits');
+  }
+
+  const json = await response.json();
+  const { data } = json;
+
+  return data;
+}
 
 export default async function KitsPage() {
-  const kits: KitCardsInfo = await prisma.kit.findMany({ select: kitCardSelect });
+  const kits = await fetchKits();
+
   return (
     <main className="w-full p-4 pt-6 grid grid-cols-2 gap-2 sm:grid-cols-3 sm:gap-3 lg:grid-cols-4 lg:gap-4">
       <h1 className="text-xl font-bold text-foreground col-span-full">등록된 키트</h1>

--- a/app/kits/page.tsx
+++ b/app/kits/page.tsx
@@ -1,7 +1,7 @@
 import KitCard from './components/KitCard';
-import { KitCardsInfo } from '@/types/Kit';
+import { KitCardInfo } from '@/types/Kit';
 
-async function fetchKits(): Promise<KitCardsInfo> {
+async function fetchKits(): Promise<KitCardInfo[]> {
   const response = await fetch('http://localhost:3000/api/kits', {
     cache: 'no-store',
   });

--- a/app/lib.tsx
+++ b/app/lib.tsx
@@ -2,8 +2,8 @@ import { Avatar, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/stories/Button';
 import { NavBarItemProps } from './types';
 import { Pencil, Stamp } from '@/lib/icons';
-import { User } from '@prisma/client';
 import { DEFAULT_PROFILE } from '@/lib/constants';
+import { UserModel } from '@/types/models';
 
 export const headerLogoItems: NavBarItemProps[] = [
   {
@@ -16,7 +16,7 @@ export const headerLogoItems: NavBarItemProps[] = [
   },
 ];
 
-export const getHeaderUserMenuItems = (user?: Pick<User, 'profileImage'>): NavBarItemProps[] => [
+export const getHeaderUserMenuItems = (user?: Pick<UserModel, 'profileImage'>): NavBarItemProps[] => [
   { href: '/kits/new', Inner: <Pencil className="h-8 w-8 fill-foreground" />, isGuest: false },
   { href: '/rallies', Inner: <Stamp className="h-8 w-8 stroke-foreground" />, isGuest: false },
   {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,11 +80,11 @@ model Kit {
   tags           String[]
   thumbnailImage String?
   rewardImage    String?
-  uploaderId     String?
+  uploaderId     String
   createdAt      DateTime  @default(now())
   updatedAt      DateTime?
   deletedAt      DateTime?
-  uploader       User?     @relation(fields: [uploaderId], references: [id])
+  uploader       User      @relation(fields: [uploaderId], references: [id])
   stamps         Stamp[]
   rallies        Rally[]
 }

--- a/types/Rally.ts
+++ b/types/Rally.ts
@@ -1,0 +1,4 @@
+import { RallyModel, UserModel } from './models';
+
+type RallyStarter = { starter: Pick<UserModel, 'profileImage' | 'nickname'> };
+export type RallyInfo = Pick<RallyModel, 'id' | 'title'> & RallyStarter;

--- a/types/kit.ts
+++ b/types/kit.ts
@@ -3,4 +3,3 @@ import { KitModel, UserModel } from './models';
 type KitCardUploader = { uploader: Pick<UserModel, 'profileImage' | 'nickname'> };
 
 export type KitCardInfo = Pick<KitModel, 'id' | 'title' | 'thumbnailImage' | 'tags'> & KitCardUploader;
-export type KitCardsInfo = KitCardInfo[];

--- a/types/kit.ts
+++ b/types/kit.ts
@@ -1,6 +1,6 @@
-import type { Prisma } from '@prisma/client';
-import type { prisma } from '@/lib/prisma';
-import type { kitCardSelect } from '@/lib/prisma';
+import { KitModel, UserModel } from './models';
 
-export type KitCardInfo = NonNullable<Prisma.Result<typeof prisma.kit, { select: typeof kitCardSelect }, 'findFirst'>>;
-export type KitCardsInfo = Prisma.Result<typeof prisma.kit, { select: typeof kitCardSelect }, 'findMany'>;
+type KitCardUploader = { uploader: Pick<UserModel, 'profileImage' | 'nickname'> };
+
+export type KitCardInfo = Pick<KitModel, 'id' | 'title' | 'thumbnailImage' | 'tags'> & KitCardUploader;
+export type KitCardsInfo = KitCardInfo[];

--- a/types/models.ts
+++ b/types/models.ts
@@ -1,0 +1,9 @@
+import type { Prisma, VerificationToken } from '@prisma/client';
+
+export type UserModel = Prisma.UserGetPayload<{ include: { accounts: true; sessions: true; kits: true; rallies: true } }>;
+export type AccountModel = Prisma.AccountGetPayload<{ include: { user: true } }>;
+export type SessionModel = Prisma.SessionGetPayload<{ include: { user: true } }>;
+export type VerificationTokenModel = VerificationToken;
+export type KitModel = Prisma.KitGetPayload<{ include: { uploader: true; stamps: true; rallies: true } }>;
+export type StampModel = Prisma.StampGetPayload<{ include: { kit: true } }>;
+export type RallyModel = Prisma.RallyGetPayload<{ include: { kit: true; starter: true } }>;


### PR DESCRIPTION
## 작업 내용

관련 이슈: #20 
이 프로젝트에서 효율적으로 백엔드 API들을 구현하기 위해 필요한 밑작업들을 확인하고 적용합니다.
확인이 필요했던 항목들 중, 이번 이슈에서는 타입정리만 진행했습니다.
다른 항목들이 이번 이슈에서 제외된 이유는 해당 이슈의 코멘트들을 확인해주세요. 

## 테스트 내용

- [x] 프론트에서 직접적으로 '@prisma/client' 를 사용하지 않게 합니다.
- [x] 모든 모델을 작성하고, 다른 분들이 타입을 유연하게 작성할 수 있도록 예시를 작성합니다.
- [x] 현재 작성되어있는 프론트 페이지에 타입을 적용합니다.


### 리뷰어에게

- 여러가지 논의해야할 곳이 많습니다.
- 제가 이번 타입 정리를 하면서 가장 중요하게 생각한 부분은 "프론트와 프리즈마의 분리" 였습니다.
- 그 외의 점들에 대해서는 많이 의견을 나누면서 정해야할 것 같습니다.

### 체크리스트

- [x] 셀프 리뷰를 진행했습니다.
- [x] 커밋 메세지를 컨벤션에 맞게 작성했습니다.
- [x] 테스트 내용에 기재된 항목에 대해서 실제로 테스트를 진행하고 동작을 확인했습니다.
