### PR TITLE
#47 태그가 두 줄이 되는 현상 해결

### DIFF
--- a/stories/Tag.tsx
+++ b/stories/Tag.tsx
@@ -37,9 +37,8 @@ interface TagProps extends ButtonBadgeProps {
  */
 export const Tag = ({ use = Uses.default, label, className, ...props }: TagProps) => {
   return (
-    <ButtonBadge className={cn('font-extralight', classNames[use], className)} variant={variants[use]} {...props}>
-      {'#'}
-      {label}
+    <ButtonBadge className={cn('font-extralight break-keep text-nowrap', classNames[use], className)} variant={variants[use]} {...props}>
+      {`#${label}`}
     </ButtonBadge>
   );
 };


### PR DESCRIPTION
## 작업 내용

관련 이슈: #47 
폭이 좁아졌을 때 태그가 두 줄이 되는 현상을 해결했습니다.

## 테스트 내용

크롬에서 CJK로 시작하는 태그를 넣고 화면폭을 줄입니다.

### 리뷰어에게

### 체크리스트

- [x] 셀프 리뷰를 진행했습니다.
- [x] 커밋 메세지를 컨벤션에 맞게 작성했습니다.
- [x] 테스트 내용에 기재된 항목에 대해서 실제로 테스트를 진행하고 동작을 확인했습니다.
