### PR TITLE
#97 완료된 랠리 페이지 레이아웃 및 #100 랠리 비소유자가 보는 페이지 레이아웃 완성

### DIFF
--- a/app/rallies/[id]/components/RallyFooter.tsx
+++ b/app/rallies/[id]/components/RallyFooter.tsx
@@ -1,8 +1,6 @@
 import { BasicButton as Button } from '@/components/ui/button';
 import { Stamp } from '@/lib/icons';
-import { cn } from '@/lib/utils';
-import { rallyFooterStyles } from './styles';
-import { RallyFooterButtonContent } from '../lib';
+import { getFooterConditions, getFooterVariant, getFooterContent, getFooterStyles } from './lib';
 import { RallyFooterInfo } from './types';
 
 interface RallyFooterProps extends RallyFooterInfo {
@@ -15,36 +13,15 @@ interface RallyFooterProps extends RallyFooterInfo {
   */
 }
 
-export function RallyFooter({ owned, variant, content }: RallyFooterProps) {
-  const is = {
-    stampable: variant === RallyFooterButtonVariant.stampable,
-    reward: variant === RallyFooterButtonVariant.reward,
-    disabled: variant === RallyFooterButtonVariant.disabled,
-  };
+export function RallyFooter(props: RallyFooterProps) {
+  const content = getFooterContent(props);
+  const is = getFooterVariant(getFooterConditions(props));
+  const styles = getFooterStyles(is);
   return (
-    <footer className={rallyFooterStyles.footer}>
-      <Button
-        className={cn(rallyFooterStyles.shareButton, {
-          [rallyFooterStyles.shareButtonDisabled]: !owned,
-        })}
-      >
-        친구에게 공유하기
-      </Button>
-      <Button
-        disabled={is.disabled}
-        className={cn(rallyFooterStyles.stampButton.default, {
-          [rallyFooterStyles.stampButton.primary]: is.stampable,
-          [rallyFooterStyles.stampButton.indigo]: is.reward,
-          [rallyFooterStyles.stampButton.grey]: is.disabled,
-        })}
-      >
-        <Stamp
-          className={cn(rallyFooterStyles.stampIcon.default, {
-            [rallyFooterStyles.stampIcon.primary]: is.stampable,
-            [rallyFooterStyles.stampIcon.indigo]: is.reward,
-            [rallyFooterStyles.stampIcon.grey]: is.disabled,
-          })}
-        />
+    <footer className={styles.footer}>
+      <Button className={styles.shareButton}>친구에게 공유하기</Button>
+      <Button disabled={is.disabled} className={styles.stampButton}>
+        {is.stampable && <Stamp className={styles.stampIcon} />}
         {content}
       </Button>
     </footer>

--- a/app/rallies/[id]/components/RallyFooter.tsx
+++ b/app/rallies/[id]/components/RallyFooter.tsx
@@ -2,28 +2,28 @@ import { BasicButton as Button } from '@/components/ui/button';
 import { Stamp } from '@/lib/icons';
 import { cn } from '@/lib/utils';
 import { rallyFooterStyles } from './styles';
-import { StampButtonContent } from '../lib';
+import { RallyFooterButtonContent } from '../lib';
 
-enum RallyStampButtonVariant {
-  Stampable = 'stampable',
-  Reward = 'reward',
-  Disabled = 'disabled',
+enum RallyFooterButtonVariant {
+  stampable = 'stampable',
+  reward = 'reward',
+  disabled = 'disabled',
 }
 
-export const getButtonVariant = (isStampable: boolean, isRewardable: boolean) =>
-  isStampable ? (isRewardable ? RallyStampButtonVariant.Reward : RallyStampButtonVariant.Stampable) : RallyStampButtonVariant.Disabled;
+export const getFooterButtonVariant = (isStampable: boolean, isRewardable: boolean) =>
+  isStampable ? (isRewardable ? RallyFooterButtonVariant.reward : RallyFooterButtonVariant.stampable) : RallyFooterButtonVariant.disabled;
 
 interface RallyFooterProps {
   owned: boolean;
-  variant: RallyStampButtonVariant;
-  stampButtonContent: StampButtonContent;
+  variant: RallyFooterButtonVariant;
+  content: RallyFooterButtonContent;
 }
 
-export function RallyFooter({ owned, variant, stampButtonContent }: RallyFooterProps) {
+export function RallyFooter({ owned, variant, content }: RallyFooterProps) {
   const is = {
-    stampable: variant === RallyStampButtonVariant.Stampable,
-    reward: variant === RallyStampButtonVariant.Reward,
-    disabled: variant === RallyStampButtonVariant.Disabled,
+    stampable: variant === RallyFooterButtonVariant.stampable,
+    reward: variant === RallyFooterButtonVariant.reward,
+    disabled: variant === RallyFooterButtonVariant.disabled,
   };
   return (
     <footer className={rallyFooterStyles.footer}>
@@ -49,7 +49,7 @@ export function RallyFooter({ owned, variant, stampButtonContent }: RallyFooterP
             [rallyFooterStyles.stampIcon.grey]: is.disabled,
           })}
         />
-        {stampButtonContent}
+        {content}
       </Button>
     </footer>
   );

--- a/app/rallies/[id]/components/RallyFooter.tsx
+++ b/app/rallies/[id]/components/RallyFooter.tsx
@@ -2,6 +2,7 @@ import { BasicButton as Button } from '@/components/ui/button';
 import { Stamp } from '@/lib/icons';
 import { cn } from '@/lib/utils';
 import { rallyFooterStyles } from './styles';
+import { StampButtonContent } from '../lib';
 
 enum RallyStampButtonVariant {
   Stampable = 'stampable',
@@ -15,9 +16,10 @@ export const getButtonVariant = (isStampable: boolean, isRewardable: boolean) =>
 interface RallyFooterProps {
   owned: boolean;
   variant: RallyStampButtonVariant;
+  stampButtonContent: StampButtonContent;
 }
 
-export function RallyFooter({ owned, variant }: RallyFooterProps) {
+export function RallyFooter({ owned, variant, stampButtonContent }: RallyFooterProps) {
   const is = {
     stampable: variant === RallyStampButtonVariant.Stampable,
     reward: variant === RallyStampButtonVariant.Reward,
@@ -41,7 +43,7 @@ export function RallyFooter({ owned, variant }: RallyFooterProps) {
             [rallyFooterStyles.stampIcon.grey]: is.disabled,
           })}
         />
-        스탬프 찍기
+        {stampButtonContent}
       </Button>
     </footer>
   );

--- a/app/rallies/[id]/components/RallyFooter.tsx
+++ b/app/rallies/[id]/components/RallyFooter.tsx
@@ -21,7 +21,7 @@ export function RallyFooter(props: RallyFooterProps) {
     <footer className={styles.footer}>
       <Button className={styles.shareButton}>친구에게 공유하기</Button>
       <Button disabled={is.disabled} className={styles.stampButton}>
-        {is.stampable && <Stamp className={styles.stampIcon} />}
+        {(is.stampable || is.reward) && <Stamp className={styles.stampIcon} />}
         {content}
       </Button>
     </footer>

--- a/app/rallies/[id]/components/RallyFooter.tsx
+++ b/app/rallies/[id]/components/RallyFooter.tsx
@@ -3,20 +3,16 @@ import { Stamp } from '@/lib/icons';
 import { cn } from '@/lib/utils';
 import { rallyFooterStyles } from './styles';
 import { RallyFooterButtonContent } from '../lib';
+import { RallyFooterInfo } from './types';
 
-enum RallyFooterButtonVariant {
-  stampable = 'stampable',
-  reward = 'reward',
-  disabled = 'disabled',
-}
-
-export const getFooterButtonVariant = (isStampable: boolean, isRewardable: boolean) =>
-  isStampable ? (isRewardable ? RallyFooterButtonVariant.reward : RallyFooterButtonVariant.stampable) : RallyFooterButtonVariant.disabled;
-
-interface RallyFooterProps {
+interface RallyFooterProps extends RallyFooterInfo {
+  /*
+  stampCount: number;
+  total: number;
   owned: boolean;
-  variant: RallyFooterButtonVariant;
-  content: RallyFooterButtonContent;
+  status: RallyStatus;
+  isStampedToday: boolean;
+  */
 }
 
 export function RallyFooter({ owned, variant, content }: RallyFooterProps) {

--- a/app/rallies/[id]/components/RallyFooter.tsx
+++ b/app/rallies/[id]/components/RallyFooter.tsx
@@ -27,7 +27,13 @@ export function RallyFooter({ owned, variant, stampButtonContent }: RallyFooterP
   };
   return (
     <footer className={rallyFooterStyles.footer}>
-      {owned && <Button className={rallyFooterStyles.shareButton}>친구에게 공유하기</Button>}
+      <Button
+        className={cn(rallyFooterStyles.shareButton, {
+          [rallyFooterStyles.shareButtonDisabled]: !owned,
+        })}
+      >
+        친구에게 공유하기
+      </Button>
       <Button
         disabled={is.disabled}
         className={cn(rallyFooterStyles.stampButton.default, {

--- a/app/rallies/[id]/components/RallyStamps.tsx
+++ b/app/rallies/[id]/components/RallyStamps.tsx
@@ -10,6 +10,9 @@ interface RallyStampsProps {
 }
 
 export default function RallyStamps({ stamps, total, stampCount, owned }: RallyStampsProps) {
+const getStampStatusUnstamped = (i: number, stampCount: number) =>
+  i < stampCount ? StampStatus.checked : i === stampCount ? StampStatus.checkable : StampStatus.uncheckable;
+const getStampStatusStamped = (i: number, stampCount: number) => (i <= stampCount ? StampStatus.checked : StampStatus.uncheckable);
   return (
     <article className={rallyStampsStyles.container}>
       <h2 className={rallyStampsStyles.title}>스탬프 랠리</h2>

--- a/app/rallies/[id]/components/RallyStamps.tsx
+++ b/app/rallies/[id]/components/RallyStamps.tsx
@@ -6,7 +6,6 @@ import { addStampPropsByIndex } from './lib';
 
 interface RallyStampsProps extends RallyStampsInfo {
   stamps: RallyPreviewStamp[];
-  isStampedToday: boolean;
 }
 
 export default function RallyStamps({ stamps, total, stampCount, owned, isStampedToday }: RallyStampsProps) {
@@ -14,7 +13,7 @@ export default function RallyStamps({ stamps, total, stampCount, owned, isStampe
     <article className={rallyStampsStyles.container}>
       <h2 className={rallyStampsStyles.title}>스탬프 랠리</h2>
       <section className={rallyStampsStyles.stamps}>
-        {stamps.map(addStampPropsByIndex({ owned, stampCount, total })).map(({ id, image, status, kind, owned, order }) => (
+        {stamps.map(addStampPropsByIndex({ owned, stampCount, total, isStampedToday })).map(({ id, image, status, kind, owned, order }) => (
           <RallyStamp key={id} id={id} image={image} status={status} kind={kind} owned={owned} order={order} />
         ))}
       </section>

--- a/app/rallies/[id]/components/RallyStamps.tsx
+++ b/app/rallies/[id]/components/RallyStamps.tsx
@@ -13,7 +13,10 @@ interface RallyStampsProps {
 const getStampStatusUnstamped = (i: number, stampCount: number) =>
   i < stampCount ? StampStatus.checked : i === stampCount ? StampStatus.checkable : StampStatus.uncheckable;
 const getStampStatusStamped = (i: number, stampCount: number) => (i <= stampCount ? StampStatus.checked : StampStatus.uncheckable);
+
 export default function RallyStamps({ stamps, total, stampCount, owned, isStampedToday }: RallyStampsProps) {
+  const getStatus = isStampedToday ? getStampStatusStamped : getStampStatusUnstamped;
+
   return (
     <article className={rallyStampsStyles.container}>
       <h2 className={rallyStampsStyles.title}>스탬프 랠리</h2>
@@ -22,7 +25,7 @@ export default function RallyStamps({ stamps, total, stampCount, owned, isStampe
           .map((e, i) => ({
             ...e,
             order: i,
-            status: i < stampCount ? StampStatus.checked : i === stampCount ? StampStatus.checkable : StampStatus.uncheckable,
+            status: getStatus(i, stampCount),
             kind: i === total - 1 ? StampKind.reward : StampKind.default,
             owned,
           }))

--- a/app/rallies/[id]/components/RallyStamps.tsx
+++ b/app/rallies/[id]/components/RallyStamps.tsx
@@ -7,12 +7,13 @@ interface RallyStampsProps {
   total: number;
   stampCount: number;
   owned: boolean;
+  isStampedToday: boolean;
 }
 
-export default function RallyStamps({ stamps, total, stampCount, owned }: RallyStampsProps) {
 const getStampStatusUnstamped = (i: number, stampCount: number) =>
   i < stampCount ? StampStatus.checked : i === stampCount ? StampStatus.checkable : StampStatus.uncheckable;
 const getStampStatusStamped = (i: number, stampCount: number) => (i <= stampCount ? StampStatus.checked : StampStatus.uncheckable);
+export default function RallyStamps({ stamps, total, stampCount, owned, isStampedToday }: RallyStampsProps) {
   return (
     <article className={rallyStampsStyles.container}>
       <h2 className={rallyStampsStyles.title}>스탬프 랠리</h2>

--- a/app/rallies/[id]/components/lib.ts
+++ b/app/rallies/[id]/components/lib.ts
@@ -5,33 +5,25 @@ import { RallyPreviewStamp } from '@/types/Stamp';
 import { rallyFooterStyles } from './styles';
 import { RallyFooterInfo, RallyStampsInfo, RewardableConditionsProps, StampableConditionsProps } from './types';
 
-const getStampStatusUnstamped = (
-  index: number,
-  count: number, // 오늘의 스탬프를 찍기 전
-) =>
-  index < count // 이미 찍은 스탬프보다 이른 차례라면
-    ? StampStatus.checked // 이미 찍은 스탬프
-    : index === count // 지금까지 찍은 스탬프와 같은 차례라면
-      ? StampStatus.checkable // 오늘의 찍을 스탬프
-      : StampStatus.uncheckable; // 다음에 찍을 스탬프
-const getStampStatusStamped = (
-  index: number,
-  count: number, // 오늘의 스탬프를 찍은 후
-) =>
-  index <= count // 이미 찍은 스탬프보다 빠른 차례라면
-    ? StampStatus.checked // 이미 찍은 스탬프
-    : StampStatus.uncheckable; // 다음에 찍을 스탬프
-const getStampStatus = (
-  isStampedToday: boolean, // 오늘의 스탬프를 찍은 여부에 따라 스탬프 상태 결정 함수 선택
-) => (isStampedToday ? getStampStatusStamped : getStampStatusUnstamped);
-
+const getStampStatus = ({ isStampedToday, index, count }: { index: number; count: number; isStampedToday: boolean }): StampStatus =>
+  isStampedToday
+    ? // 오늘 스탬프를 찍었고
+      index <= count // 이미 찍은 스탬프보다 이르거나 같은 차례라면
+      ? StampStatus.checked // 이미 찍은 스탬프 (le)
+      : StampStatus.uncheckable // 아니면 다음에 찍을 스탬프 (gt)
+    : // 오늘 스탬프를 찍지 않았고
+      index < count // 이미 찍은 스탬프보다 이른 차례라면
+      ? StampStatus.checked // 이미 찍은 스탬프 (lt)
+      : index === count // 이미 찍은 스탬프와 같은 차례라면
+        ? StampStatus.checkable // 오늘의 찍을 스탬프 (eq)
+        : StampStatus.uncheckable; // 둘다 아니면 다음에 찍을 스탬프 (gt)
 const getStampKind = (index: number, total: number) => (index === total - 1 ? StampKind.reward : StampKind.default);
 export const addStampPropsByIndex =
-  ({ owned, stampCount, total, isStampedToday }: RallyStampsInfo) =>
+  ({ owned, stampCount: count, total, isStampedToday }: RallyStampsInfo) =>
   (stamp: RallyPreviewStamp, index: number) => ({
     ...stamp,
     order: index,
-    status: getStampStatus(isStampedToday)(index, stampCount),
+    status: getStampStatus({ isStampedToday, index, count }),
     kind: getStampKind(index, total),
     owned,
   });

--- a/app/rallies/[id]/components/lib.ts
+++ b/app/rallies/[id]/components/lib.ts
@@ -41,7 +41,7 @@ export const addStampPropsByIndex =
 enum RallyFooterButtonContent {
   NotOwned = '이 키트로 랠리 시작하기',
   Success = '스탬프 랠리 완주 성공!',
-  StampedToday = '오늘의 스탬프 클리어!',
+  StampedToday = '오늘의 목표를 완료했어요!',
   Stampable = '스탬프 찍기',
 }
 const footerButtonContents = [

--- a/app/rallies/[id]/components/lib.ts
+++ b/app/rallies/[id]/components/lib.ts
@@ -1,6 +1,8 @@
+import { cn } from '@/lib/utils';
 import { StampStatus, StampKind } from '@/components/RallyStamp';
 import { RallyStatus } from '@/types/Rally';
 import { RallyPreviewStamp } from '@/types/Stamp';
+import { rallyFooterStyles } from './styles';
 import { RallyFooterInfo, RallyStampsInfo, RewardableConditionsProps, StampableConditionsProps } from './types';
 
 const getStampStatusUnstamped = (
@@ -72,3 +74,39 @@ const getSatisfiedIndex = (props: StampableConditionsProps) => getStampableCondi
  * @returns {RallyFooterButtonContent}
  */
 export const getFooterContent = (props: StampableConditionsProps) => footerButtonContents.at(getSatisfiedIndex(props));
+
+/**
+ * 랠리를 소유하고, 완료하지 않았고, 오늘 스탬프를 찍지 않았으면 스탬프를 찍을 수 있음
+ */
+const getStampable = (props: StampableConditionsProps) => getSatisfiedIndex(props) === -1;
+/**
+ * 리워드를 찍을 수 있는 경우 (마지막 스탬프만 남겨둔 경우)
+ */
+const getRewardable = ({ stampCount, total }: RewardableConditionsProps) => stampCount === total - 1;
+export const getFooterConditions = (props: RallyFooterInfo) => ({
+  stampable: getStampable(props),
+  rewardable: getRewardable(props),
+  owned: props.owned,
+});
+export const getFooterVariant = ({ stampable, rewardable, owned }: ReturnType<typeof getFooterConditions>) => ({
+  notOwned: !owned, // 소유하지 않은 경우
+  disabled: owned && !stampable, // 스탬프를 찍을 수 없는 경우 (오늘 스탬프를 찍었거나 랠리를 완료한 경우)
+  reward: owned && stampable && rewardable,
+  stampable: owned && stampable && !rewardable, // (리워드가 아닌) 스탬프를 찍을 수 있는 경우
+});
+export const getFooterStyles = ({ stampable, reward, notOwned, disabled }: ReturnType<typeof getFooterVariant>) => ({
+  footer: rallyFooterStyles.footer,
+  shareButton: cn(rallyFooterStyles.shareButton, {
+    [rallyFooterStyles.shareButtonDisabled]: notOwned,
+  }),
+  stampButton: cn(rallyFooterStyles.stampButton.default, {
+    [rallyFooterStyles.stampButton.primary]: stampable,
+    [rallyFooterStyles.stampButton.indigo]: reward,
+    [rallyFooterStyles.stampButton.grey]: disabled,
+    [rallyFooterStyles.stampButton.primary]: notOwned,
+  }),
+  stampIcon: cn(rallyFooterStyles.stampIcon.default, {
+    [rallyFooterStyles.stampIcon.primary]: stampable,
+    [rallyFooterStyles.stampIcon.indigo]: reward,
+  }),
+});

--- a/app/rallies/[id]/components/lib.ts
+++ b/app/rallies/[id]/components/lib.ts
@@ -2,18 +2,33 @@ import { StampStatus, StampKind } from '@/components/RallyStamp';
 import { RallyPreviewStamp } from '@/types/Stamp';
 import { RallyStampsInfo } from './types';
 
-const getStampStatus = (index: number, count: number) => {
-  if (index < count) return StampStatus.checked;
-  if (index === count) return StampStatus.checkable;
-  return StampStatus.uncheckable;
-};
+const getStampStatusUnstamped = (
+  index: number,
+  count: number, // 오늘의 스탬프를 찍기 전
+) =>
+  index < count // 이미 찍은 스탬프보다 이른 차례라면
+    ? StampStatus.checked // 이미 찍은 스탬프
+    : index === count // 지금까지 찍은 스탬프와 같은 차례라면
+      ? StampStatus.checkable // 오늘의 찍을 스탬프
+      : StampStatus.uncheckable; // 다음에 찍을 스탬프
+const getStampStatusStamped = (
+  index: number,
+  count: number, // 오늘의 스탬프를 찍은 후
+) =>
+  index <= count // 이미 찍은 스탬프보다 빠른 차례라면
+    ? StampStatus.checked // 이미 찍은 스탬프
+    : StampStatus.uncheckable; // 다음에 찍을 스탬프
+const getStampStatus = (
+  isStampedToday: boolean, // 오늘의 스탬프를 찍은 여부에 따라 스탬프 상태 결정 함수 선택
+) => (isStampedToday ? getStampStatusStamped : getStampStatusUnstamped);
+
 const getStampKind = (index: number, total: number) => (index === total - 1 ? StampKind.reward : StampKind.default);
 export const addStampPropsByIndex =
-  ({ owned, stampCount, total }: RallyStampsInfo) =>
+  ({ owned, stampCount, total, isStampedToday }: RallyStampsInfo) =>
   (stamp: RallyPreviewStamp, index: number) => ({
     ...stamp,
     order: index,
-    status: getStampStatus(index, stampCount),
+    status: getStampStatus(isStampedToday)(index, stampCount),
     kind: getStampKind(index, total),
     owned,
   });

--- a/app/rallies/[id]/components/lib.ts
+++ b/app/rallies/[id]/components/lib.ts
@@ -1,6 +1,7 @@
 import { StampStatus, StampKind } from '@/components/RallyStamp';
+import { RallyStatus } from '@/types/Rally';
 import { RallyPreviewStamp } from '@/types/Stamp';
-import { RallyStampsInfo } from './types';
+import { RallyFooterInfo, RallyStampsInfo, RewardableConditionsProps, StampableConditionsProps } from './types';
 
 const getStampStatusUnstamped = (
   index: number,
@@ -32,3 +33,42 @@ export const addStampPropsByIndex =
     kind: getStampKind(index, total),
     owned,
   });
+
+// Footer
+
+enum RallyFooterButtonContent {
+  NotOwned = '이 키트로 랠리 시작하기',
+  Success = '스탬프 랠리 완주 성공!',
+  StampedToday = '오늘의 스탬프 클리어!',
+  Stampable = '스탬프 찍기',
+}
+const footerButtonContents = [
+  RallyFooterButtonContent.NotOwned,
+  RallyFooterButtonContent.Success,
+  RallyFooterButtonContent.StampedToday,
+  RallyFooterButtonContent.Stampable,
+] as const;
+/**
+ * 스탬프를 찍을 수 있는 조건
+ * @returns [소유 여부, 완료 여부, 오늘 스탬프 찍었는지 여부]
+ */
+const getStampableConditions = ({ owned, status, isStampedToday }: StampableConditionsProps) =>
+  [
+    !owned, // 소유 여부
+    status === RallyStatus.inactive, // 완료 여부
+    isStampedToday, // 오늘 스탬프 찍었는지 여부
+  ] as const;
+/**
+ * 처음으로 만족하는 조건의 인덱스 반환
+ * @returns {number} 0: 소유하지 않은 경우, 1: 완료한 경우, 2: 오늘 스탬프를 찍은 경우, -1: 스탬프 찍을 수 있는 경우
+ */
+const getSatisfiedIndex = (props: StampableConditionsProps) => getStampableConditions(props).findIndex(Boolean);
+/**
+ * 만족하는 조건의 인덱스가
+ * -  0: 소유하지 않았으므로 NotOwned 반환
+ * -  1: 완료했으므로 Success 반환
+ * -  2: 오늘 스탬프를 찍었으므로 StampedToday 반환
+ * - -1: 스탬프를 찍을 수 있으므로 Stampable 반환
+ * @returns {RallyFooterButtonContent}
+ */
+export const getFooterContent = (props: StampableConditionsProps) => footerButtonContents.at(getSatisfiedIndex(props));

--- a/app/rallies/[id]/components/styles.ts
+++ b/app/rallies/[id]/components/styles.ts
@@ -17,6 +17,7 @@ export const rallyStampsStyles = {
 export const rallyFooterStyles = {
   footer: 'mt-auto flex flex-col gap-2',
   shareButton: 'w-full bg-background text-grey-400 border border-grey-100',
+  shareButtonDisabled: 'opacity-0 cursor-default',
   stampButton: {
     default: 'w-full',
     primary: 'bg-primary',

--- a/app/rallies/[id]/components/types.ts
+++ b/app/rallies/[id]/components/types.ts
@@ -2,4 +2,5 @@ export interface RallyStampsInfo {
   total: number;
   stampCount: number;
   owned: boolean;
+  isStampedToday: boolean;
 }

--- a/app/rallies/[id]/components/types.ts
+++ b/app/rallies/[id]/components/types.ts
@@ -1,6 +1,18 @@
+import { RallyStatus } from '@/types/Rally';
+
 export interface RallyStampsInfo {
   total: number;
   stampCount: number;
   owned: boolean;
   isStampedToday: boolean;
 }
+export interface RewardableConditionsProps {
+  stampCount: number;
+  total: number;
+}
+export interface StampableConditionsProps {
+  owned: boolean;
+  status: RallyStatus;
+  isStampedToday: boolean;
+}
+export interface RallyFooterInfo extends RewardableConditionsProps, StampableConditionsProps {}

--- a/app/rallies/[id]/lib.ts
+++ b/app/rallies/[id]/lib.ts
@@ -31,39 +31,3 @@ export const dummy = {
     updatedAt: null,
   },
 } satisfies { data: RallyInfo };
-
-interface StampableConditionsProps {
-  owned: boolean;
-  status: RallyStatus;
-  // stampCount: number;
-  // total: number;
-  isStampedToday: boolean;
-}
-const getStampableConditions = ({ owned, status, /* stampCount, total, */ isStampedToday }: StampableConditionsProps) => [
-  owned,
-  status === RallyStatus.active,
-  // stampCount < total,
-  !isStampedToday,
-];
-export const getStampable = (props: StampableConditionsProps) => getStampableConditions(props).every(Boolean);
-export enum RallyFooterButtonContent {
-  Stampable = '스탬프 찍기',
-  NotOwned = '이 키트로 랠리 시작하기',
-  StampedToday = '오늘의 스탬프 클리어!',
-  Success = '스탬프 랠리 완주 성공!',
-  // Fail = '스탬프 랠리 실패 ㅠㅠ',
-}
-export const getFooterButtonContent = (props: StampableConditionsProps): RallyFooterButtonContent => {
-  const [isNotOwned, isInactive, /* isFull, */ isNotStampedToday] = getStampableConditions(props).map((e) => !e);
-  switch (true) {
-    case isNotOwned:
-      return RallyFooterButtonContent.NotOwned;
-    case isInactive:
-      return RallyFooterButtonContent.Success; // isFull ? StampButtonContent.Success : StampButtonContent.Fail;
-    case isNotStampedToday:
-      return RallyFooterButtonContent.StampedToday;
-    // case isFail: return StampButtonContent.Fail;
-  }
-  // case owned && status === "active" && !isStampedToday:
-  return RallyFooterButtonContent.Stampable;
-};

--- a/app/rallies/[id]/lib.ts
+++ b/app/rallies/[id]/lib.ts
@@ -35,14 +35,14 @@ export const dummy = {
 interface StampableConditionsProps {
   owned: boolean;
   status: RallyStatus;
-  stampCount: number;
-  total: number;
+  // stampCount: number;
+  // total: number;
   isStampedToday: boolean;
 }
-const getStampableConditions = ({ owned, status, stampCount, total, isStampedToday }: StampableConditionsProps) => [
+const getStampableConditions = ({ owned, status, /* stampCount, total, */ isStampedToday }: StampableConditionsProps) => [
   owned,
   status === RallyStatus.active,
-  stampCount < total,
+  // stampCount < total,
   !isStampedToday,
 ];
 export const getStampable = (props: StampableConditionsProps) => getStampableConditions(props).every(Boolean);
@@ -51,15 +51,15 @@ export enum StampButtonContent {
   NotOwned = '이 키트로 랠리 시작하기',
   StampedToday = '오늘의 스탬프 클리어!',
   Success = '스탬프 랠리 완주 성공!',
-  Fail = '스탬프 랠리 실패 ㅠㅠ',
+  // Fail = '스탬프 랠리 실패 ㅠㅠ',
 }
 export const getStampButtonContent = (props: StampableConditionsProps): StampButtonContent => {
-  const [isNotOwned, isInactive, isFull, isNotStampedToday] = getStampableConditions(props).map((e) => !e);
+  const [isNotOwned, isInactive, /* isFull, */ isNotStampedToday] = getStampableConditions(props).map((e) => !e);
   switch (true) {
     case isNotOwned:
       return StampButtonContent.NotOwned;
     case isInactive:
-      return isFull ? StampButtonContent.Success : StampButtonContent.Fail;
+      return StampButtonContent.Success; // isFull ? StampButtonContent.Success : StampButtonContent.Fail;
     case isNotStampedToday:
       return StampButtonContent.StampedToday;
     // case isFail: return StampButtonContent.Fail;

--- a/app/rallies/[id]/lib.ts
+++ b/app/rallies/[id]/lib.ts
@@ -45,3 +45,4 @@ const getStampableConditions = ({ owned, status, stampCount, total, isStampedTod
   stampCount < total,
   !isStampedToday,
 ];
+export const getStampable = (props: StampableConditionsProps) => getStampableConditions(props).every(Boolean);

--- a/app/rallies/[id]/lib.ts
+++ b/app/rallies/[id]/lib.ts
@@ -15,16 +15,15 @@ export const dummy = {
       tags: ['6일_챌린지'],
       thumbnailImage: 'https://picsum.photos/360',
       rewardImage: 'https://picsum.photos/360',
-      stamps: Array(6)
-        .fill(null)
-        .map(
-          (_, i) =>
-            ({
-              id: `stamp-${i}`,
-              kitId: '0000002',
-              image: `https://picsum.photos/360?random=${i}`,
-            }) satisfies Pick<StampModel, 'id' | 'image' | 'kitId'>,
-        ),
+      stamps: Array.from(
+        { length: 6 },
+        (_, i) =>
+          ({
+            id: `stamp-${i}`,
+            kitId: '0000002',
+            image: `https://picsum.photos/360?random=${i}`,
+          }) satisfies Pick<StampModel, 'id' | 'image' | 'kitId'>,
+      ),
       // uploader: { id: 'clwnjgnpl000fdnxe0xbwk5qv', email: 'user12@example.com', image: 'https://picsum.photos/360', name: 'User12' },
       // createdAt: '2024-05-26T12:51:33.034Z',
       // updatedAt: null,

--- a/app/rallies/[id]/lib.ts
+++ b/app/rallies/[id]/lib.ts
@@ -31,3 +31,9 @@ export const dummy = {
     updatedAt: null,
   },
 } satisfies { data: RallyInfo };
+// TODO: 레이아웃 테스트용 임시 변수를 ID로부터 추출하는 함수
+export const getTempValue = (id: string) => ({
+  stampCount: Number(id.at(0)), // ID 첫자리를 전날까지 찍은 스탬프 개수로 사용
+  isStampedToday: id.at(1) === '1', // ID 둘째자리를 오늘 스탬프 여부로 사용
+  owned: id.at(2) !== '1', // ID 셋째자리를 소유 여부로 사용 // user?.id === starter.id;
+});

--- a/app/rallies/[id]/lib.ts
+++ b/app/rallies/[id]/lib.ts
@@ -1,4 +1,4 @@
-import { RallyInfo } from '@/types/Rally';
+import { RallyInfo, RallyStatus } from '@/types/Rally';
 
 // TODO: 테스트용 상수 제거
 export const dummy = {
@@ -31,3 +31,17 @@ export const dummy = {
     updatedAt: null,
   },
 } satisfies { data: RallyInfo };
+
+interface StampableConditionsProps {
+  owned: boolean;
+  status: RallyStatus;
+  stampCount: number;
+  total: number;
+  isStampedToday: boolean;
+}
+const getStampableConditions = ({ owned, status, stampCount, total, isStampedToday }: StampableConditionsProps) => [
+  owned,
+  status === RallyStatus.active,
+  stampCount < total,
+  !isStampedToday,
+];

--- a/app/rallies/[id]/lib.ts
+++ b/app/rallies/[id]/lib.ts
@@ -46,24 +46,24 @@ const getStampableConditions = ({ owned, status, /* stampCount, total, */ isStam
   !isStampedToday,
 ];
 export const getStampable = (props: StampableConditionsProps) => getStampableConditions(props).every(Boolean);
-export enum StampButtonContent {
+export enum RallyFooterButtonContent {
   Stampable = '스탬프 찍기',
   NotOwned = '이 키트로 랠리 시작하기',
   StampedToday = '오늘의 스탬프 클리어!',
   Success = '스탬프 랠리 완주 성공!',
   // Fail = '스탬프 랠리 실패 ㅠㅠ',
 }
-export const getStampButtonContent = (props: StampableConditionsProps): StampButtonContent => {
+export const getFooterButtonContent = (props: StampableConditionsProps): RallyFooterButtonContent => {
   const [isNotOwned, isInactive, /* isFull, */ isNotStampedToday] = getStampableConditions(props).map((e) => !e);
   switch (true) {
     case isNotOwned:
-      return StampButtonContent.NotOwned;
+      return RallyFooterButtonContent.NotOwned;
     case isInactive:
-      return StampButtonContent.Success; // isFull ? StampButtonContent.Success : StampButtonContent.Fail;
+      return RallyFooterButtonContent.Success; // isFull ? StampButtonContent.Success : StampButtonContent.Fail;
     case isNotStampedToday:
-      return StampButtonContent.StampedToday;
+      return RallyFooterButtonContent.StampedToday;
     // case isFail: return StampButtonContent.Fail;
   }
   // case owned && status === "active" && !isStampedToday:
-  return StampButtonContent.Stampable;
+  return RallyFooterButtonContent.Stampable;
 };

--- a/app/rallies/[id]/lib.ts
+++ b/app/rallies/[id]/lib.ts
@@ -46,3 +46,24 @@ const getStampableConditions = ({ owned, status, stampCount, total, isStampedTod
   !isStampedToday,
 ];
 export const getStampable = (props: StampableConditionsProps) => getStampableConditions(props).every(Boolean);
+export enum StampButtonContent {
+  Stampable = '스탬프 찍기',
+  NotOwned = '이 키트로 랠리 시작하기',
+  StampedToday = '오늘의 스탬프 클리어!',
+  Success = '스탬프 랠리 완주 성공!',
+  Fail = '스탬프 랠리 실패 ㅠㅠ',
+}
+export const getStampButtonContent = (props: StampableConditionsProps): StampButtonContent => {
+  const [isNotOwned, isInactive, isFull, isNotStampedToday] = getStampableConditions(props).map((e) => !e);
+  switch (true) {
+    case isNotOwned:
+      return StampButtonContent.NotOwned;
+    case isInactive:
+      return isFull ? StampButtonContent.Success : StampButtonContent.Fail;
+    case isNotStampedToday:
+      return StampButtonContent.StampedToday;
+    // case isFail: return StampButtonContent.Fail;
+  }
+  // case owned && status === "active" && !isStampedToday:
+  return StampButtonContent.Stampable;
+};

--- a/app/rallies/[id]/lib.ts
+++ b/app/rallies/[id]/lib.ts
@@ -1,4 +1,5 @@
 import { RallyInfo, RallyStatus } from '@/types/Rally';
+import { StampModel } from '@/types/models';
 
 // TODO: 테스트용 상수 제거
 export const dummy = {
@@ -16,11 +17,14 @@ export const dummy = {
       rewardImage: 'https://picsum.photos/360',
       stamps: Array(6)
         .fill(null)
-        .map((_, i) => ({
-          id: `stamp-${i}`,
-          kitId: '0000002',
-          image: `https://picsum.photos/360?random=${i}`,
-        })),
+        .map(
+          (_, i) =>
+            ({
+              id: `stamp-${i}`,
+              kitId: '0000002',
+              image: `https://picsum.photos/360?random=${i}`,
+            }) satisfies Pick<StampModel, 'id' | 'image' | 'kitId'>,
+        ),
       // uploader: { id: 'clwnjgnpl000fdnxe0xbwk5qv', email: 'user12@example.com', image: 'https://picsum.photos/360', name: 'User12' },
       // createdAt: '2024-05-26T12:51:33.034Z',
       // updatedAt: null,
@@ -37,3 +41,18 @@ export const getTempValue = (id: string) => ({
   isStampedToday: id.at(1) === '1', // ID 둘째자리를 오늘 스탬프 여부로 사용
   owned: id.at(2) !== '1', // ID 셋째자리를 소유 여부로 사용 // user?.id === starter.id;
 });
+export const getRallyInfo = ({
+  stamps,
+  stampCount,
+  isStampedToday,
+}: {
+  stamps: Pick<StampModel, 'id' | 'image' | 'kitId'>[];
+  stampCount: number;
+  isStampedToday: boolean;
+}) => {
+  const total = stamps.length;
+  const count = stampCount + Number(isStampedToday); // 오늘까지 찍은 스탬프 개수
+  const status = count === total ? RallyStatus.inactive : RallyStatus.active; // TODO: 레이아웃 테스트용 임시 변수로 도장을 모두 채웠다면 'active', 아니면 'inactive'
+  const percentage = (count / total) * 100;
+  return { total, count, status, percentage };
+};

--- a/app/rallies/[id]/page.tsx
+++ b/app/rallies/[id]/page.tsx
@@ -27,13 +27,13 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
   } = rally;
   const total = stamps.length;
   const stampCount = Number(id.at(0)); // TODO: 레이아웃 테스트용 임시 변수로 ID 첫자리를 스탬프 개수로 사용
-  const status = stampCount === total ? 'inactive' : 'active'; // TODO: 레이아웃 테스트용 임시 변수로 도장을 모두 채웠거나 ID 셋째자리가 '1'이면 'inactive', '0'이면 'active'
+  const isStampedToday = id.at(1) === '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 둘째자리를 오늘 스탬프 여부로 사용
+  const status = stampCount + Number(isStampedToday) === total ? 'inactive' : 'active'; // TODO: 레이아웃 테스트용 임시 변수로 도장을 모두 채웠거나 ID 셋째자리가 '1'이면 'inactive', '0'이면 'active'
   const percentage = (stampCount / total) * 100;
   // // TODO: D-day 계산 방법 << DB 에 종료 예정일(기한) 필드 추가 필요 -> 기한 추가 시 재검토
   // let deadline = new Date();
   // deadline.setDate(deadline.getDate() + 8);
   const owned = id.at(2) !== '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 넷째자리를 소유 여부로 사용 // user?.id === starter.id;
-  const isStampedToday = id.at(1) === '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 둘째자리를 오늘 스탬프 여부로 사용
   const stampableProps = { owned, status, stampCount, total, isStampedToday } as const;
   const isStampable = getStampable(stampableProps);
   const isRewardable = stampCount === total - 1;

--- a/app/rallies/[id]/page.tsx
+++ b/app/rallies/[id]/page.tsx
@@ -27,14 +27,14 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
   } = rally;
   const total = stamps.length;
   const stampCount = Number(id.at(0)); // TODO: 레이아웃 테스트용 임시 변수로 ID 첫자리를 스탬프 개수로 사용
-  const status = stampCount === total || id.at(3) === '1' ? 'inactive' : 'active'; // TODO: 레이아웃 테스트용 임시 변수로 도장을 모두 채웠거나 ID 넷째자리가 '1'이면 'inactive', '0'이면 'active'
+  const status = stampCount === total || id.at(2) === '1' ? 'inactive' : 'active'; // TODO: 레이아웃 테스트용 임시 변수로 도장을 모두 채웠거나 ID 넷째자리가 '1'이면 'inactive', '0'이면 'active'
   const percentage = (stampCount / total) * 100;
   // // TODO: D-day 계산 방법 << DB 에 종료 예정일(기한) 필드 추가 필요 -> 기한 추가 시 재검토
   // let deadline = new Date();
   // deadline.setDate(deadline.getDate() + 8);
   const owned = true; // user?.id === starter.id;
   // const isUpdatedToday = false;
-  const isStampedToday = id.at(2) !== '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 셋째자리를 오늘 스탬프 여부로 사용
+  const isStampedToday = id.at(1) !== '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 셋째자리를 오늘 스탬프 여부로 사용
   const stampableProps = { owned, status, stampCount, total, isStampedToday } as const;
   const isStampable = getStampable(stampableProps);
   const isRewardable = stampCount === total - 1;

--- a/app/rallies/[id]/page.tsx
+++ b/app/rallies/[id]/page.tsx
@@ -1,9 +1,9 @@
 // import { notFound } from 'next/navigation';
 // import { getMember } from '@/auth';
-import { dummy, getStampable, getFooterButtonContent } from './lib';
+import { dummy } from './lib';
 import RallyInfo from './components/RallyInfo';
 import RallyStamps from './components/RallyStamps';
-import { RallyFooter, getFooterButtonVariant } from './components/RallyFooter';
+import { RallyFooter } from './components/RallyFooter';
 
 interface RallyPageProps {
   params: { id: string };
@@ -34,17 +34,13 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
   // let deadline = new Date();
   // deadline.setDate(deadline.getDate() + 8);
   const owned = id.at(2) !== '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 넷째자리를 소유 여부로 사용 // user?.id === starter.id;
-  const stampableProps = { owned, status, stampCount, total, isStampedToday } as const;
-  const isStampable = getStampable(stampableProps);
-  const isRewardable = stampCount === total - 1;
-  const stampButtonVariant = getFooterButtonVariant(isStampable, isRewardable);
-  const stampButtonContent = getFooterButtonContent(stampableProps);
+  // const stampableProps = { owned, status, stampCount, total, isStampedToday } as const;
 
   return (
     <main className="px-4 py-6 w-full bg-grey-50 flex flex-col gap-6">
       <RallyInfo title={title} percentage={percentage} createdAt={createdAt} updatedAt={updatedAt} status={status} /* deadline={deadline} */ />
       <RallyStamps stamps={stamps} total={total} stampCount={stampCount} owned={owned} isStampedToday={isStampedToday} />
-      <RallyFooter owned={owned} variant={stampButtonVariant} content={stampButtonContent} />
+      <RallyFooter owned={owned} status={status} stampCount={stampCount} total={total} isStampedToday={isStampedToday} />
     </main>
   );
 }

--- a/app/rallies/[id]/page.tsx
+++ b/app/rallies/[id]/page.tsx
@@ -17,15 +17,17 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
   // const user = await getMember(); // TODO: 로직 중 isStampable 계산 시 사용 예정
   const {
     title,
-    stampCount,
+    // stampCount, TODO: 로직 완료 후 주석 해제
     createdAt,
     updatedAt,
     kit: { stamps },
-    status, // TODO: 활성화 / 비활성화 보다는 진행 / 완료 / 실패로 나누는게 어떤지 검토
+    // status, // TODO: 로직 완료 후 주석 해제 // TODO: 활성화 / 비활성화 보다는 진행 / 완료 / 실패로 나누는게 어떤지 검토
     // description, // TODO: 상세 설명을 표시 칸 추가
     // starter, // TODO: 로직 중 isStampable 계산 시 사용 예정
   } = rally;
   const total = stamps.length;
+  const stampCount = Number(id.at(0)); // TODO: 레이아웃 테스트용 임시 변수로 ID 첫자리를 스탬프 개수로 사용
+  const status = stampCount === total || id.at(3) === '1' ? 'inactive' : 'active'; // TODO: 레이아웃 테스트용 임시 변수로 도장을 모두 채웠거나 ID 넷째자리가 '1'이면 'inactive', '0'이면 'active'
   const percentage = (stampCount / total) * 100;
   // TODO: D-day 계산 방법 << DB 에 종료 예정일(기한) 필드 추가 필요
   // 임시로 7일 뒤 종료로 설정

--- a/app/rallies/[id]/page.tsx
+++ b/app/rallies/[id]/page.tsx
@@ -1,6 +1,6 @@
 // import { notFound } from 'next/navigation';
 // import { getMember } from '@/auth';
-import { dummy, getTempValue } from './lib';
+import { dummy, getRallyInfo, getTempValue } from './lib';
 import RallyInfo from './components/RallyInfo';
 import RallyStamps from './components/RallyStamps';
 import { RallyFooter } from './components/RallyFooter';
@@ -27,16 +27,13 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
   } = rally;
   // TODO: 레이아웃 테스트용 임시 변수로 ID 첫자리를 전날까지 찍은 스탬프 개수, 둘째자리를 오늘 스탬프 여부, 셋째자리를 소유 여부로 사용
   const { stampCount, owned, isStampedToday } = getTempValue(id);
-  const total = stamps.length;
-  const count = stampCount + Number(isStampedToday); // 오늘까지 찍은 스탬프 개수
-  const status = count === total ? 'inactive' : 'active'; // TODO: 레이아웃 테스트용 임시 변수로 도장을 모두 채웠다면 'active', 아니면 'inactive'
-  const percentage = (count / total) * 100;
+  const { total, count, status, percentage } = getRallyInfo({ stamps, stampCount, isStampedToday });
 
   return (
     <main className="px-4 py-6 w-full bg-grey-50 flex flex-col gap-6">
       <RallyInfo title={title} percentage={percentage} createdAt={createdAt} updatedAt={updatedAt} status={status} /* deadline={deadline} */ />
-      <RallyStamps stamps={stamps} total={total} stampCount={stampCount} owned={owned} isStampedToday={isStampedToday} />
-      <RallyFooter owned={owned} status={status} stampCount={stampCount} total={total} isStampedToday={isStampedToday} />
+      <RallyStamps owned={owned} stamps={stamps} stampCount={count} total={total} isStampedToday={isStampedToday} />
+      <RallyFooter owned={owned} status={status} stampCount={count} total={total} isStampedToday={isStampedToday} />
     </main>
   );
 }

--- a/app/rallies/[id]/page.tsx
+++ b/app/rallies/[id]/page.tsx
@@ -27,12 +27,12 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
   } = rally;
   const total = stamps.length;
   const stampCount = Number(id.at(0)); // TODO: 레이아웃 테스트용 임시 변수로 ID 첫자리를 스탬프 개수로 사용
-  const status = stampCount === total || id.at(2) === '1' ? 'inactive' : 'active'; // TODO: 레이아웃 테스트용 임시 변수로 도장을 모두 채웠거나 ID 셋째자리가 '1'이면 'inactive', '0'이면 'active'
+  const status = stampCount === total ? 'inactive' : 'active'; // TODO: 레이아웃 테스트용 임시 변수로 도장을 모두 채웠거나 ID 셋째자리가 '1'이면 'inactive', '0'이면 'active'
   const percentage = (stampCount / total) * 100;
   // // TODO: D-day 계산 방법 << DB 에 종료 예정일(기한) 필드 추가 필요 -> 기한 추가 시 재검토
   // let deadline = new Date();
   // deadline.setDate(deadline.getDate() + 8);
-  const owned = id.at(3) !== '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 넷째자리를 소유 여부로 사용 // user?.id === starter.id;
+  const owned = id.at(2) !== '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 넷째자리를 소유 여부로 사용 // user?.id === starter.id;
   const isStampedToday = id.at(1) === '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 둘째자리를 오늘 스탬프 여부로 사용
   const stampableProps = { owned, status, stampCount, total, isStampedToday } as const;
   const isStampable = getStampable(stampableProps);

--- a/app/rallies/[id]/page.tsx
+++ b/app/rallies/[id]/page.tsx
@@ -43,7 +43,7 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
   const stampButtonContent = getStampButtonContent(stampableProps);
 
   return (
-    <main className="px-4 py-6 bg-grey-50 flex flex-col gap-6">
+    <main className="px-4 py-6 w-full bg-grey-50 flex flex-col gap-6">
       <RallyInfo title={title} percentage={percentage} createdAt={createdAt} updatedAt={updatedAt} status={status} deadline={deadline} />
       <RallyStamps stamps={stamps} total={total} stampCount={stampCount} owned={owned} isStampedToday={isStampedToday} />
       <RallyFooter owned={owned} variant={stampButtonVariant} stampButtonContent={stampButtonContent} />

--- a/app/rallies/[id]/page.tsx
+++ b/app/rallies/[id]/page.tsx
@@ -1,6 +1,6 @@
 // import { notFound } from 'next/navigation';
 // import { getMember } from '@/auth';
-import { dummy } from './lib';
+import { dummy, getTempValue } from './lib';
 import RallyInfo from './components/RallyInfo';
 import RallyStamps from './components/RallyStamps';
 import { RallyFooter } from './components/RallyFooter';
@@ -25,10 +25,9 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
     // description, // TODO: 상세 설명을 표시 칸 추가
     // starter, // TODO: 로직 중 isStampable 계산 시 사용 예정
   } = rally;
+  // TODO: 레이아웃 테스트용 임시 변수로 ID 첫자리를 전날까지 찍은 스탬프 개수, 둘째자리를 오늘 스탬프 여부, 셋째자리를 소유 여부로 사용
+  const { stampCount, owned, isStampedToday } = getTempValue(id);
   const total = stamps.length;
-  const stampCount = Number(id.at(0)); // TODO: 레이아웃 테스트용 임시 변수로 ID 첫자리를 전날까지 찍은 스탬프 개수로 사용
-  const isStampedToday = id.at(1) === '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 둘째자리를 오늘 스탬프 여부로 사용
-  const owned = id.at(2) !== '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 셋째자리를 소유 여부로 사용 // user?.id === starter.id;
   const count = stampCount + Number(isStampedToday); // 오늘까지 찍은 스탬프 개수
   const status = count === total ? 'inactive' : 'active'; // TODO: 레이아웃 테스트용 임시 변수로 도장을 모두 채웠다면 'active', 아니면 'inactive'
   const percentage = (count / total) * 100;

--- a/app/rallies/[id]/page.tsx
+++ b/app/rallies/[id]/page.tsx
@@ -1,9 +1,9 @@
 // import { notFound } from 'next/navigation';
 // import { getMember } from '@/auth';
-import { dummy, getStampable, getStampButtonContent } from './lib';
+import { dummy, getStampable, getFooterButtonContent } from './lib';
 import RallyInfo from './components/RallyInfo';
 import RallyStamps from './components/RallyStamps';
-import { RallyFooter, getButtonVariant } from './components/RallyFooter';
+import { RallyFooter, getFooterButtonVariant } from './components/RallyFooter';
 
 interface RallyPageProps {
   params: { id: string };
@@ -37,14 +37,14 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
   const stampableProps = { owned, status, stampCount, total, isStampedToday } as const;
   const isStampable = getStampable(stampableProps);
   const isRewardable = stampCount === total - 1;
-  const stampButtonVariant = getButtonVariant(isStampable, isRewardable);
-  const stampButtonContent = getStampButtonContent(stampableProps);
+  const stampButtonVariant = getFooterButtonVariant(isStampable, isRewardable);
+  const stampButtonContent = getFooterButtonContent(stampableProps);
 
   return (
     <main className="px-4 py-6 w-full bg-grey-50 flex flex-col gap-6">
       <RallyInfo title={title} percentage={percentage} createdAt={createdAt} updatedAt={updatedAt} status={status} /* deadline={deadline} */ />
       <RallyStamps stamps={stamps} total={total} stampCount={stampCount} owned={owned} isStampedToday={isStampedToday} />
-      <RallyFooter owned={owned} variant={stampButtonVariant} stampButtonContent={stampButtonContent} />
+      <RallyFooter owned={owned} variant={stampButtonVariant} content={stampButtonContent} />
     </main>
   );
 }

--- a/app/rallies/[id]/page.tsx
+++ b/app/rallies/[id]/page.tsx
@@ -27,14 +27,13 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
   } = rally;
   const total = stamps.length;
   const stampCount = Number(id.at(0)); // TODO: 레이아웃 테스트용 임시 변수로 ID 첫자리를 스탬프 개수로 사용
-  const status = stampCount === total || id.at(2) === '1' ? 'inactive' : 'active'; // TODO: 레이아웃 테스트용 임시 변수로 도장을 모두 채웠거나 ID 넷째자리가 '1'이면 'inactive', '0'이면 'active'
+  const status = stampCount === total || id.at(2) === '1' ? 'inactive' : 'active'; // TODO: 레이아웃 테스트용 임시 변수로 도장을 모두 채웠거나 ID 셋째자리가 '1'이면 'inactive', '0'이면 'active'
   const percentage = (stampCount / total) * 100;
   // // TODO: D-day 계산 방법 << DB 에 종료 예정일(기한) 필드 추가 필요 -> 기한 추가 시 재검토
   // let deadline = new Date();
   // deadline.setDate(deadline.getDate() + 8);
-  const owned = true; // user?.id === starter.id;
-  // const isUpdatedToday = false;
-  const isStampedToday = id.at(1) !== '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 셋째자리를 오늘 스탬프 여부로 사용
+  const owned = id.at(3) !== '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 넷째자리를 소유 여부로 사용 // user?.id === starter.id;
+  const isStampedToday = id.at(1) === '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 둘째자리를 오늘 스탬프 여부로 사용
   const stampableProps = { owned, status, stampCount, total, isStampedToday } as const;
   const isStampable = getStampable(stampableProps);
   const isRewardable = stampCount === total - 1;

--- a/app/rallies/[id]/page.tsx
+++ b/app/rallies/[id]/page.tsx
@@ -1,6 +1,6 @@
 // import { notFound } from 'next/navigation';
 // import { getMember } from '@/auth';
-import { dummy } from './lib';
+import { dummy, getStampable, getStampButtonContent } from './lib';
 import RallyInfo from './components/RallyInfo';
 import RallyStamps from './components/RallyStamps';
 import { RallyFooter, getButtonVariant } from './components/RallyFooter';
@@ -33,14 +33,18 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
   deadline.setDate(deadline.getDate() + 8);
   const owned = true; // user?.id === starter.id;
   // const isUpdatedToday = false;
-  const isStampable = true; // owned && status === 'active' && (isUpdatedToday || stampCount < total);
+  const isStampedToday = id.at(2) !== '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 셋째자리를 오늘 스탬프 여부로 사용
+  const stampableProps = { owned, status, stampCount, total, isStampedToday } as const;
+  const isStampable = getStampable(stampableProps);
   const isRewardable = stampCount === total - 1;
   const stampButtonVariant = getButtonVariant(isStampable, isRewardable);
+  const stampButtonContent = getStampButtonContent(stampableProps);
+
   return (
     <main className="px-4 py-6 bg-grey-50 flex flex-col gap-6">
       <RallyInfo title={title} percentage={percentage} createdAt={createdAt} updatedAt={updatedAt} status={status} deadline={deadline} />
-      <RallyStamps stamps={stamps} total={total} stampCount={stampCount} owned={owned} />
-      <RallyFooter owned={owned} variant={stampButtonVariant} />
+      <RallyStamps stamps={stamps} total={total} stampCount={stampCount} owned={owned} isStampedToday={isStampedToday} />
+      <RallyFooter owned={owned} variant={stampButtonVariant} stampButtonContent={stampButtonContent} />
     </main>
   );
 }

--- a/app/rallies/[id]/page.tsx
+++ b/app/rallies/[id]/page.tsx
@@ -26,15 +26,12 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
     // starter, // TODO: 로직 중 isStampable 계산 시 사용 예정
   } = rally;
   const total = stamps.length;
-  const stampCount = Number(id.at(0)); // TODO: 레이아웃 테스트용 임시 변수로 ID 첫자리를 스탬프 개수로 사용
+  const stampCount = Number(id.at(0)); // TODO: 레이아웃 테스트용 임시 변수로 ID 첫자리를 전날까지 찍은 스탬프 개수로 사용
   const isStampedToday = id.at(1) === '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 둘째자리를 오늘 스탬프 여부로 사용
-  const status = stampCount + Number(isStampedToday) === total ? 'inactive' : 'active'; // TODO: 레이아웃 테스트용 임시 변수로 도장을 모두 채웠거나 ID 셋째자리가 '1'이면 'inactive', '0'이면 'active'
-  const percentage = (stampCount / total) * 100;
-  // // TODO: D-day 계산 방법 << DB 에 종료 예정일(기한) 필드 추가 필요 -> 기한 추가 시 재검토
-  // let deadline = new Date();
-  // deadline.setDate(deadline.getDate() + 8);
-  const owned = id.at(2) !== '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 넷째자리를 소유 여부로 사용 // user?.id === starter.id;
-  // const stampableProps = { owned, status, stampCount, total, isStampedToday } as const;
+  const owned = id.at(2) !== '1'; // TODO: 레이아웃 테스트용 임시 변수로 ID 셋째자리를 소유 여부로 사용 // user?.id === starter.id;
+  const count = stampCount + Number(isStampedToday); // 오늘까지 찍은 스탬프 개수
+  const status = count === total ? 'inactive' : 'active'; // TODO: 레이아웃 테스트용 임시 변수로 도장을 모두 채웠다면 'active', 아니면 'inactive'
+  const percentage = (count / total) * 100;
 
   return (
     <main className="px-4 py-6 w-full bg-grey-50 flex flex-col gap-6">

--- a/app/rallies/page.tsx
+++ b/app/rallies/page.tsx
@@ -2,8 +2,28 @@ import RallyCard from '@/components/RallyCard';
 import { JoinedRally } from '@/types/Rally';
 import Link from 'next/link';
 
+const dummy = Array.from({ length: 6 }, (_, i) => Array.from('01', (j) => Array.from('01', (k) => `${i}${j}${k}`)))
+  .flat(2)
+  .map(
+    (id) =>
+      ({
+        id,
+        status: 'active',
+        stampCount: Number(id.at(0)),
+        updatedAt: null,
+        kit: {
+          thumbnailImage: `https://picsum.photos/360?random=${id}`,
+          title: `랠리 ${id}`,
+          _count: {
+            stamps: 6,
+          },
+        },
+      }) satisfies JoinedRally,
+  );
+
 export default async function RalliesPage() {
-  const { data: rallies }: { data: JoinedRally[] } = await fetch(process.env.API_URL + '/api/my/joins').then((res) => res.json());
+  const { data: rallies }: { data: JoinedRally[] } = { data: dummy };
+  // await fetch(process.env.API_URL + '/api/my/joins').then((res) => res.json());
   return (
     <main className="px-4 py-6 grid grid-cols-2 gap-x-2 gap-y-4">
       {rallies.map(


### PR DESCRIPTION
## 작업 내용

관련 이슈: #97 #101
- 리워드를 얻을 수 경우
  `/rallies/5` 에서 확인하실 수 있습니다.
  ![image](https://github.com/ZZIPSA/kkuk-kkuk-fe/assets/61987505/b1e76bfe-cab4-4261-b79f-f03dc432d9bc)
- #97 
  `/rallies/6` 에서 확인하실 수 있습니다.
  ![image](https://github.com/ZZIPSA/kkuk-kkuk-fe/assets/61987505/ba82962e-36c0-4f9e-b8a8-ab786231e7e0)
- #101
  `/rallies/101` 에서 확인하실 수 있습니다.
  ![image](https://github.com/ZZIPSA/kkuk-kkuk-fe/assets/61987505/a297dd7f-dd7c-43ab-8816-d025b85322f2)
- #97 + #101
  `/rallies/601` 에서 확인하실 수 있습니다.
  ![image](https://github.com/ZZIPSA/kkuk-kkuk-fe/assets/61987505/ec606d54-09b9-4d9e-b80a-7e59f0aa4b77)


## 테스트 내용

예상대로 작동하지 않는 경우를 쉽게 공유하기 위해 임시로 경로 내 랠리의 ID를 이용해 랠리의 상태를 확인할 수 있도록 처리했습니다.

`/rallies/xyz`
x: 0~6 찍기 전 찍혀있는 스탬프 수
y?: 1 인 경우 오늘의 스탬프 찍은 상태
z?: 1 인 경우 자신이 소유하지 않은 스탬프 페이지

예:
- `/rallies/3`: 3번째 스탬프까지 찍혀있고 4번째 스탬프를 찍기 전
- `/rallies/31`: 3번째 스탬프까지 찍고 4번째 스탬프를 오늘 찍은 경우
- `/rallies/301`: 3번째 스탬프까지 찍혀있고 4번째 스탬프를 찍기 전 다른 사람이 보는 경우 #101 
- `/rallies/6`: 모든 스탬프를 완료한 경우 #97 
- `/rallies/6`: 모든 스탬프를 완료한 랠리를 다른 사람이 보는 경우 #97 + #101

### 리뷰어에게

예상대로 작동하지 않는 페이지가 있는 경우 해당 페이지 번호를 남겨주시면 감사하겠습니다.

### 체크리스트

- [x] 셀프 리뷰를 진행했습니다.
- [x] 커밋 메세지를 컨벤션에 맞게 작성했습니다.
- [x] 테스트 내용에 기재된 항목에 대해서 실제로 테스트를 진행하고 동작을 확인했습니다.
