### PR TITLE
issue/#105 feat: auth관련 API 수정

### DIFF
--- a/app/api/kits/route.ts
+++ b/app/api/kits/route.ts
@@ -24,14 +24,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   // TODO: auth, 필수 항목 검증 미들웨어 구현
-  const session = await auth();
-  const currentUser = session?.user;
-
-  if (!currentUser) return NextResponse.json({ error: '로그인 해주세요.' }, { status: 401 });
-
-  const uploaderId = currentUser.id;
-
-  const { title, description, imageUrls, thumbnailImage, rewardImage, blurredImage, tags } = await request.json();
+  const { title, description, imageUrls, thumbnailImage, rewardImage, blurredImage, tags, userId: uploaderId } = await request.json();
   const s3 = new S3Manager();
 
   if (!title || !Array.isArray(imageUrls) || !thumbnailImage || !rewardImage || !blurredImage || !uploaderId) {

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -2,14 +2,14 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 
-export async function GET() {
-  const session = await auth();
-  const currentUser = session?.user;
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const userId = searchParams.get('userId');
 
-  if (!currentUser) return NextResponse.json({ error: '로그인 해주세요.' }, { status: 401 });
+  if (!userId) return NextResponse.json({ error: '로그인 해주세요.' }, { status: 401 });
 
   const user = await prisma.user.findUnique({
-    where: { id: currentUser.id },
+    where: { id: userId },
   });
 
   return NextResponse.json({ data: user });

--- a/app/api/my/rallies/route.ts
+++ b/app/api/my/rallies/route.ts
@@ -1,16 +1,15 @@
 import { NextResponse } from 'next/server';
 import { prisma, rallySelect } from '@/lib/prisma';
-import { auth } from '@/auth';
 
 // TODO: MVP 이후 페이지네이션, 파람 구현
-export async function GET() {
-  const session = await auth();
-  const currentUser = session?.user;
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const userId = searchParams.get('userId');
 
-  if (!currentUser) return NextResponse.json({ error: '로그인 해주세요.' }, { status: 401 });
+  if (!userId) return NextResponse.json({ error: '로그인 해주세요.' }, { status: 401 });
 
   try {
-    const rallies = await prisma.rally.findMany({ where: { starterId: currentUser.id }, select: rallySelect });
+    const rallies = await prisma.rally.findMany({ where: { starterId: userId }, select: rallySelect });
 
     return NextResponse.json({
       data: rallies,

--- a/app/api/rallies/route.ts
+++ b/app/api/rallies/route.ts
@@ -3,15 +3,9 @@ import { auth } from '@/auth';
 import { prisma, kitSelect, userSelect } from '@/lib/prisma';
 
 export async function POST(request: Request) {
+  // TODO: auth, 필수 항목 검증 미들웨어 구현
   const body = await request.json();
-  const session = await auth();
-  const currentUser = session?.user;
-
-  if (!currentUser) return NextResponse.json({ error: '로그인 해주세요.' }, { status: 401 });
-
-  const starterId = currentUser.id;
-
-  const { title, description, kitId } = body;
+  const { title, description, kitId, userId: starterId } = body;
 
   if (!title || !kitId || !starterId) {
     return NextResponse.json({ error: '요청이 유효하지 않습니다.' }, { status: 400 });

--- a/app/my/(info)/completes/page.tsx
+++ b/app/my/(info)/completes/page.tsx
@@ -5,7 +5,7 @@ import { RallyStatus, MyRally } from '@/types/Rally';
 
 export default async function CompletesPage() {
   const { id: userId } = await ensureMember();
-  const api = `${process.env.API_URL}/api/user/${userId}/rallies`;
+  const api = `${process.env.API_URL}/api/my/rallies?userId=${userId}`;
   const { data: rallies }: { data: MyRally[] } = await fetch(api).then((res) => res.json());
 
   return (

--- a/app/my/(info)/joins/page.tsx
+++ b/app/my/(info)/joins/page.tsx
@@ -5,7 +5,7 @@ import { MyRally, RallyStatus } from '@/types/Rally';
 
 export default async function JoinsPage() {
   const { id: userId } = await ensureMember();
-  const api = `${process.env.API_URL}/api/user/${userId}/rallies`;
+  const api = `${process.env.API_URL}/api/my/rallies?userId=${userId}`;
   const { data: rallies }: { data: MyRally[] } = await fetch(api).then((res) => res.json());
 
   return (

--- a/components/UserInfo/index.tsx
+++ b/components/UserInfo/index.tsx
@@ -14,11 +14,12 @@ interface UserInfoProps {
 
 export default async function UserInfo({ variant = UserInfoVariant.default }: UserInfoProps) {
   const { id: userId } = await ensureMember();
-  const api = `${process.env.API_URL}/api/user/${userId}`;
+  // TODO: 파람을 전송하지 않도록 수정
+  const api = `${process.env.API_URL}/api/me?userId=${userId}`;
   const {
     data: { image, name, accounts, rallies },
   }: { data: UserInfoResult } = await fetch(api).then((res) => res.json());
-  const twitterAccount = accounts.find(({ provider }) => provider === 'twitter');
+  // const twitterAccount = accounts.find(({ provider }) => provider === 'twitter');
 
   return (
     <section className="flex flex-col py-6 px-4 gap-4">
@@ -35,14 +36,16 @@ export default async function UserInfo({ variant = UserInfoVariant.default }: Us
           )}
         </span>
         {variant === UserInfoVariant.default && <h1 className="font-bold w-full">{name}</h1>}
-        {twitterAccount && (
+        {/* // NOTE: 페이즈 1에서 구현 */}
+        {/* {twitterAccount && (
           <Badge variant="secondary" className="w-fit text-xs font-normal gap-2">
             <span className="text-2xl">𝕏</span>@{twitterAccount.userId}
           </Badge>
-        )}
+        )} */}
       </div>
       {variant === UserInfoVariant.default && <RalliesCounts rallies={rallies ?? []} />}
-      {variant === UserInfoVariant.settings && <NicknameInput name={name} />}
+      {/* // TODO: name의 nullable을 허용하지 않도록 수정 */}
+      {variant === UserInfoVariant.settings && <NicknameInput name={name ?? ''} />}
     </section>
   );
 }


### PR DESCRIPTION
## 작업 내용

관련 이슈: #105

서버에서 서버로 요청을 보낼 때 헤더에 쿠키가 붙지않습니다. 이에 따라 MVP 기능이 동작하도록 API의 auth 관련 처리를 수정했습니다.

## 테스트 내용

- [x] API 및 해당 화면에서의 동작확인

### 리뷰어에게

**매우 좋지않은 수정을 진행했습니다.**
#### 수정 내용
- 인증, 인가가 필요한 API에 대해서 인증, 인가 처리를 제외시켰습니다.
- 1차적으로 프론트에서 보안을 진행하고 있습니다.
- Next.js 14와 앱라우터 자체에 대한 심도있는 이해가 필요하나, 현재 추가적으로 공부할 시간이 마땅치 않아 우선 최소한의 동작만을 보장하도록 수정했습니다.
- 목요일에 MVP 배포 예정에 있으나, 당장 사용하는 다른 유저들은 없을 예정이므로 이대로 배포하고 이번주 주말까지 좀 더 깊이 있는 수정을 할 수 있도록 공부해오겠습니다.

#### 수정 방향
- 가급적 프론트의 코드는 많이 수정하고 싶지 않았습니다. 프론트 코드에 대해서 파악이 안되어있을 뿐더러, actions로 변경했을 경우 타입문제가 다수 발생해 수습에 더 많은 시간이 걸릴 것으로 예상했습니다. 페이즈 1 이후에는 리퀘스트, 리스폰스 타입에 대해서 정의하고 진행할 수 있도록 하겠습니다.
- 프론트에서 보내는 요청에 credential과 쿠키를 수동으로 붙여서 요청해보았으나, 마찬가지로 session이 null이었습니다. 원인은 불명이나 원인규명에 투자할 시간이 부족하여 이 방법도 패스했습니다.

#### 배경
- 최초 프레임워크 선정 때부터 고려했어야하는 사항들에 대해서 충분히 검토하지 않아 발생한 수정입니다.
- 애초에 Next.js 14와 앱 라우터는 프론트에서 직접 데이터베이스에 접속하는 것을 베스트 프랙티스로 표시하고 있습니다.
- 서버에서 서버로 요청을 할 때는 헤더에 쿠키가 붙지않아 인증이 불가합니다. 또한 API 함수 내에서 자체적으로 auth()로 인증을 진행해도 null로 표시됩니다.
- 포스트맨에서는 헤더에 쿠키를 붙여서 보내면 정상적으로 동작이 됩니다. 이 버그에 대한 파악이 늦어진 이유입니다.



### 체크리스트

- [x] 셀프 리뷰를 진행했습니다.
- [x] 커밋 메세지를 컨벤션에 맞게 작성했습니다.
- [x] 테스트 내용에 기재된 항목에 대해서 실제로 테스트를 진행하고 동작을 확인했습니다.
