### PR TITLE
#123 #113 머지 이후 빌드 시 발생하는 에러 해결

### DIFF
--- a/app/error-page-for-dev/page.tsx
+++ b/app/error-page-for-dev/page.tsx
@@ -1,6 +1,0 @@
-/**
- * 에러를 확인하기 위한 페이지입니다. 배포 시 지워도 무방합니다.
- */
-export default function ErrorPageForDev() {
-  return Response.error();
-}

--- a/prisma/seed-user-rally.ts
+++ b/prisma/seed-user-rally.ts
@@ -36,9 +36,10 @@ async function main() {
     data: Array.from({ length: 20 }, (_, i) => ({
       id: (Number(id) + i + 1).toString().padStart(7, '0'),
       title: `업로드 키트 ${i + 1}`,
+      blurredImage: `https://picsum.photos/360?random=${i}`,
       description: `${i + 1}번 업로드 키트 설명`,
-      thumbnailImage: `https://picsum.photos/${360 + i}`,
-      rewardImage: `https://picsum.photos/${360 + i}`,
+      thumbnailImage: `https://picsum.photos/360?random=${i}`,
+      rewardImage: `https://picsum.photos/360?random=${i}`,
       uploaderId: user.id,
     })),
   });

--- a/stories/Input.stories.ts
+++ b/stories/Input.stories.ts
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from '@storybook/test';
 import { TextInput, Variants } from './Input';
 
 const meta = {
@@ -7,7 +6,6 @@ const meta = {
   component: TextInput,
   parameters: { layout: 'centered' },
   tags: ['autodocs'],
-  args: { onClick: fn() },
 } satisfies Meta<typeof TextInput>;
 
 export default meta;

--- a/types/Kit.ts
+++ b/types/Kit.ts
@@ -1,6 +1,6 @@
 import { KitModel, StampModel, UserModel } from './models';
 
-type KitUploader = { uploader: Pick<UserModel, 'id' | 'nickname' | 'profileImage'> };
+type KitUploader = { uploader: Pick<UserModel, 'id' | 'name' | 'image'> };
 type KitStamps = { stamps: Pick<StampModel, 'id' | 'image'>[] };
 export type KitResult = Pick<KitModel, 'id' | 'title' | 'description' | 'tags' | 'thumbnailImage' | 'rewardImage'> & KitUploader & KitStamps;
 


### PR DESCRIPTION
## 작업 내용

관련 이슈: #123 
#113 머지 이후 빌드 시에 발생하는 에러를 해결했습니다.
- `./prisma/seed-user-rally.ts:36:5` 에서 발생하는 `Type error`
  - 원인: 테스트용 시드 생성 코드가 최신 스키마와 맞지 않아 타입 에러가 발생했습니다. 
  - 해결: 시드 코드를 변경했습니다. 6e38d472e38bcfe12857886e16b77bea0a277f63
- `./stories/Input.stories.ts:10:11` 에서 발생하는 `Type error`
  - 원인: 목업용 코드의 타입이 맞지 않았습니다.
  - 해결: 필요하지 않은 코드를 제거했습니다. 12c5029e05f25812fa89656ccd83ddfd65e511e1
- `./types/Kit.ts:3:48` 에서 발생하는 `Type error`
  - 원인: 기존에 지정해 둔 타입의 컬럼명이 스키마 변경 이후로 변경되지 않아 타입 에러가 발생했습니다. 
  - 해결: 해당 타입의 컬럼명을 변경했습니다. 12c5029e05f25812fa89656ccd83ddfd65e511e1
- 빌드가 끝나지 않는 무한 빌드 오류
  - 원인: 에러 페이지 테스트용으로 에러가 발생하게 만든 페이지에서 에러가 발생했다고 여겨 빌드가 완료되지 않았습니다.
  - 해결: 에러 페이지 테스트용 페이지 `app/error-page-for-dev/page.tsx` 를 제거했습니다. fc64fa29960f4fe7f29834bbc2f7d4601e078f7a

## 테스트 내용

```bash
yarn build
yarn start
```

### 리뷰어에게

변경된 파일 보다는 커밋 단위로 변경 사항을 봐주시면 좋을 것 같습니다.

#### 리뷰하기 전

#### 리뷰 후

### 체크리스트

- [ ] 리뷰하는데 20분 이상 필요한가요? _20분 초과할 경우, 예상 리뷰 시간을 덧붙여주세요_
- [ ] 셀프 리뷰를 진행했습니다.
- [x] 커밋 메세지를 컨벤션에 맞게 작성했습니다.
- [x] 테스트 내용에 기재된 항목에 대해서 실제로 테스트를 진행하고 동작을 확인했습니다.
