### PR TITLE
Issue/186 랠리 연장, 랠리 삭제, 조회 파람 추가

### DIFF
--- a/app/(back)/rallies/[id]/components/RallyFooter.tsx
+++ b/app/(back)/rallies/[id]/components/RallyFooter.tsx
@@ -19,7 +19,7 @@ export function RallyFooter(props: RallyFooterProps) {
   const styles = getFooterStyles(is);
 
   const onClick = async () => {
-    const response = await fetch(`/api/rallies/${rallyId}`, {
+    const response = await fetch(`/api/rallies/${rallyId}/stamp`, {
       method: 'PATCH',
     });
     if (response.ok) {

--- a/app/api/kits/[id]/route.ts
+++ b/app/api/kits/[id]/route.ts
@@ -11,7 +11,7 @@ export async function GET(_: Request, { params }: GetKitParams) {
 
   try {
     const kit = (await prisma.kit.findUnique({
-      where: { id },
+      where: { id, deletedAt: null },
       select: kitSelect,
     })) satisfies KitData | null;
 

--- a/app/api/kits/[id]/route.ts
+++ b/app/api/kits/[id]/route.ts
@@ -31,12 +31,7 @@ export async function DELETE(_: Request, { params }: DeleteKitParams) {
 
     if (!kit) NotFoundKitError;
 
-    const deletedKit = await prisma.kit.update({
-      where: { id },
-      data: { deletedAt: new Date() },
-    });
-
-    return NextResponse.json({ data: deletedKit }, { status: 200 });
+    return NextResponse.json({ data: '키트가 삭제되었습니다.' }, { status: 200 });
   } catch (error) {
     return ServerError;
   }

--- a/app/api/kits/[id]/route.ts
+++ b/app/api/kits/[id]/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server';
 import { kitSelect, prisma } from '@/app/api/lib/prisma';
+import { NotFoundKitError, ServerError } from '@/app/api/lib/errors';
 import { KitData } from '@/types/Kit';
 
-type getKitParams = { params: { id: string } };
+type GetKitParams = { params: { id: string } };
+type DeleteKitParams = { params: { id: string } };
 
-export async function GET(_: Request, { params }: getKitParams) {
+export async function GET(_: Request, { params }: GetKitParams) {
   const { id } = params;
 
   try {
@@ -13,12 +15,29 @@ export async function GET(_: Request, { params }: getKitParams) {
       select: kitSelect,
     })) satisfies KitData | null;
 
-    if (!kit) {
-      return NextResponse.json({ error: '해당 키트를 찾을 수 없습니다.' }, { status: 404 });
-    }
+    if (!kit) return NotFoundKitError;
 
     return NextResponse.json({ data: kit }, { status: 200 });
   } catch (error) {
-    return NextResponse.json({ error: '서버 에러가 발생했습니다.' }, { status: 500 });
+    return ServerError;
+  }
+}
+
+export async function DELETE(_: Request, { params }: DeleteKitParams) {
+  const { id } = params;
+
+  try {
+    const kit = await prisma.kit.findUnique({ where: { id } });
+
+    if (!kit) NotFoundKitError;
+
+    const deletedKit = await prisma.kit.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+
+    return NextResponse.json({ data: deletedKit }, { status: 200 });
+  } catch (error) {
+    return ServerError;
   }
 }

--- a/app/api/kits/route.ts
+++ b/app/api/kits/route.ts
@@ -12,7 +12,6 @@ type GetKitsParams = { params: { cursor?: string; pageSize?: string; order?: Sor
 
 export async function GET(request: Request, { params }: GetKitsParams) {
   try {
-    // params가 undefined일 수 있으므로 기본값을 설정합니다.
     const { cursor = null, pageSize = null, order: orderParam = 'desc' } = params || {};
     const order: SortOrder = orderParam === 'asc' ? 'asc' : 'desc';
 

--- a/app/api/kits/route.ts
+++ b/app/api/kits/route.ts
@@ -1,63 +1,34 @@
-import cuid from 'cuid';
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
-import { kitSelect, prisma } from '@/app/api/lib/prisma';
-import { extractImageIdFromUrl, getStampsCreate, uploadWebp } from '@/app/api/lib/utils';
+import { prisma } from '@/app/api/lib/prisma';
 import { S3Manager } from '@/lib/services/s3';
+import { extractImageIdFromUrl, getAllKits, getBlurredImageURL, getNewKitId, getPagedKits, getStampsCreate } from '@/app/api/lib/utils';
 import { BLURRED_IMAGE_INDEX, REWARD_IMAGE_INDEX, THUMBNAIL_IMAGE_INDEX } from '@/app/api/lib/constants';
+import { BadRequestError, ServerError } from '@/app/api/lib/errors';
+import { SortOrder } from '@/app/api/lib/types';
 import { CreateKitProps } from '@/types/Kit';
-import { blurImage } from '@/lib/sharp';
 
-export async function GET(request: Request) {
+type GetKitsParams = { params: { cursor?: string; pageSize?: string; order?: SortOrder } };
+
+export async function GET(request: Request, { params }: GetKitsParams) {
   try {
-    const { searchParams } = new URL(request.url);
-    const cursor = searchParams.get('cursor');
-    const pageSize = searchParams.get('pageSize');
+    // params가 undefined일 수 있으므로 기본값을 설정합니다.
+    const { cursor = null, pageSize = null, order: orderParam = 'desc' } = params || {};
+    const order: SortOrder = orderParam === 'asc' ? 'asc' : 'desc';
 
     if (pageSize) {
-      const { kits, meta } = await getPagedKits(parseInt(pageSize, 10), cursor);
+      if (!cursor) return BadRequestError;
+
+      const { kits, meta } = await getPagedKits(parseInt(pageSize, 10), cursor, order);
       return NextResponse.json({ data: kits, meta });
     } else {
-      const { kits, totalKits } = await getAllKits();
+      const { kits, totalKits } = await getAllKits(order);
       return NextResponse.json({ data: kits, meta: { totalKits } });
     }
   } catch (error) {
-    return NextResponse.json({ error: '서버 에러가 발생했습니다.' }, { status: 500 });
+    console.error(error);
+    return ServerError;
   }
-}
-
-async function getPagedKits(pageSize: number, cursor: string | null) {
-  const take = pageSize;
-  const kits = await prisma.kit.findMany({
-    take,
-    skip: cursor ? 1 : 0,
-    cursor: cursor ? { id: cursor } : undefined,
-    orderBy: {
-      id: 'asc',
-    },
-    select: kitSelect,
-  });
-
-  const totalKits = await prisma.kit.count();
-  const totalPages = Math.ceil(totalKits / pageSize);
-  const nextCursor = kits.length === take ? kits[take - 1].id : null;
-
-  return {
-    kits,
-    meta: {
-      nextCursor,
-      pageSize,
-      totalKits,
-      totalPages,
-    },
-  };
-}
-
-async function getAllKits() {
-  const kits = await prisma.kit.findMany({ select: kitSelect });
-  const totalKits = await prisma.kit.count();
-
-  return { kits, totalKits };
 }
 
 export async function POST(request: Request) {
@@ -67,9 +38,8 @@ export async function POST(request: Request) {
   const uploaderId = user?.id;
   const { title, description, stamps: imageUrls, tags } = (await request.json()) satisfies CreateKitProps;
 
-  if (!title || !Array.isArray(imageUrls) || !uploaderId) {
-    return NextResponse.json({ error: '필수 항목을 입력해주세요.' }, { status: 400 });
-  }
+  if (!title || !Array.isArray(imageUrls) || !uploaderId) return BadRequestError;
+
   const id = await getNewKitId();
 
   // 리워드 이미지 id 로 블러 이미지 생성
@@ -78,9 +48,7 @@ export async function POST(request: Request) {
 
   try {
     const s3 = new S3Manager();
-    // s3 에서 이미지를 long-term storage로 이동
     const newKeys = await s3.moveToLongTermStorage([...imageUrls, blurredImage], id);
-    // 키트 생성
     const kit = await prisma.kit.create({
       data: {
         id,
@@ -98,35 +66,6 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ data: kit });
   } catch (error) {
-    return NextResponse.json({ error: '서버 에러가 발생했습니다.' }, { status: 500 });
+    return ServerError;
   }
-}
-
-/**
- * 가장 마지막 Kit의 id를 가져와 새로운 Kit의 id를 생성합니다.
- * Kit 가 없을 경우 0000001을 반환합니다.
- *
- * @returns kitId
- */
-async function getNewKitId() {
-  const lastKit = await prisma.kit.findFirst({ orderBy: { id: 'desc' }, select: { id: true } });
-  const lastId = lastKit?.id || '0';
-  const kitId = String(Number(lastId) + 1).padStart(7, '0');
-  return kitId;
-}
-
-/**
- * 리워드 이미지 ID를 받아 블러 처리된 이미지 URL을 반환합니다.
- *
- * @param id 리워드 이미지 ID
- * @returns 블러 처리된 이미지 URL
- */
-async function getBlurredImageURL(id: string) {
-  const s3 = new S3Manager();
-  const signedUrl = await s3.getObjectUrl(`tmp/${id}`);
-  const buffer = await fetch(signedUrl).then((res) => res.arrayBuffer());
-  const blurredBuffer = await blurImage(buffer);
-  const blurredUrl = await s3.getPresignedUrl(cuid());
-  await uploadWebp(blurredBuffer, blurredUrl);
-  return blurredUrl;
 }

--- a/app/api/lib/errors.ts
+++ b/app/api/lib/errors.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 
 export const NotFoundRallyError = NextResponse.json({ error: '해당 랠리를 찾을 수 없습니다.' }, { status: 404 });
+export const NotFoundKitError = NextResponse.json({ error: '해당 키트를 찾을 수 없습니다.' }, { status: 404 });
 export const ServerError = NextResponse.json({ error: '서버 에러가 발생했습니다.' }, { status: 500 });
 export const UnauthorizedError = NextResponse.json({ error: '로그인 해주세요.' }, { status: 401 });
 export const BadRequestError = NextResponse.json({ error: '필수 항목을 입력해주세요.' }, { status: 400 });

--- a/app/api/lib/prisma/db.ts
+++ b/app/api/lib/prisma/db.ts
@@ -10,8 +10,8 @@ const prisma = new PrismaClient().$extends({
 
           const currentDate = new Date();
           const targetDate = new Date(rally.lastStampDate);
-
           const fiveAMToday = new Date(currentDate);
+
           fiveAMToday.setHours(5, 0, 0, 0);
 
           return targetDate < fiveAMToday;

--- a/app/api/lib/prisma/db.ts
+++ b/app/api/lib/prisma/db.ts
@@ -1,5 +1,24 @@
 import { PrismaClient } from '@prisma/client';
 
-const prisma = new PrismaClient();
+const prisma = new PrismaClient().$extends({
+  result: {
+    rally: {
+      stampable: {
+        needs: { lastStampDate: true },
+        compute(rally) {
+          if (!rally.lastStampDate) return true;
+
+          const currentDate = new Date();
+          const targetDate = new Date(rally.lastStampDate);
+
+          const fiveAMToday = new Date(currentDate);
+          fiveAMToday.setHours(5, 0, 0, 0);
+
+          return targetDate < fiveAMToday;
+        },
+      },
+    },
+  },
+});
 
 export default prisma;

--- a/app/api/lib/prisma/selects.ts
+++ b/app/api/lib/prisma/selects.ts
@@ -35,6 +35,11 @@ export const rallySelect = {
     select: userSelect,
   },
   stampCount: true,
+  lastStampDate: true,
+  dueDate: true,
+  completionDate: true,
+  extendedDueDate: true,
+  isPublic: true,
   createdAt: true,
   updatedAt: true,
 } satisfies Prisma.RallySelect;

--- a/app/api/lib/types.ts
+++ b/app/api/lib/types.ts
@@ -1,0 +1,3 @@
+import { Prisma } from '@prisma/client';
+
+export type SortOrder = Prisma.SortOrder;

--- a/app/api/lib/utils.ts
+++ b/app/api/lib/utils.ts
@@ -25,6 +25,7 @@ export async function getPagedKits(pageSize: number, cursor: string | null, orde
       createdAt: order,
     },
     select: kitSelect,
+    where: { deletedAt: null },
   });
 
   const totalKits = await prisma.kit.count();
@@ -48,6 +49,7 @@ export async function getAllKits(order: SortOrder) {
       createdAt: order,
     },
     select: kitSelect,
+    where: { deletedAt: null },
   });
   const totalKits = await prisma.kit.count();
 

--- a/app/api/lib/utils.ts
+++ b/app/api/lib/utils.ts
@@ -1,4 +1,9 @@
-import { RallyStatus } from '@prisma/client';
+import cuid from 'cuid';
+import { Prisma, RallyStatus } from '@prisma/client';
+import { blurImage } from '@/lib/sharp';
+import { S3Manager } from '@/lib/services/s3';
+import { kitSelect, prisma } from '@/app/api/lib/prisma';
+import { SortOrder } from '@/app/api/lib/types';
 
 export const extractImageIdFromUrl = (url: string) => url.substring(url.lastIndexOf('/') + 1, url.lastIndexOf('?'));
 export const getStampsCreate = (keys: string[]) => ({
@@ -9,6 +14,74 @@ export const getStampsCreate = (keys: string[]) => ({
 const removeReward = (_: string, i: number, { length }: string[]) => i !== length - 2;
 const getStampCreateFromKey = (objectKey: string) => ({ id: extractImageIdFromKey(objectKey), objectKey });
 const extractImageIdFromKey = (key: string) => key.substring(key.lastIndexOf('/') + 1);
+
+export async function getPagedKits(pageSize: number, cursor: string | null, order: SortOrder) {
+  const take = pageSize;
+  const kits = await prisma.kit.findMany({
+    take,
+    skip: cursor ? 1 : 0,
+    cursor: cursor ? { id: cursor } : undefined,
+    orderBy: {
+      createdAt: order,
+    },
+    select: kitSelect,
+  });
+
+  const totalKits = await prisma.kit.count();
+  const totalPages = Math.ceil(totalKits / pageSize);
+  const nextCursor = kits.length === take ? kits[take - 1].id : null;
+
+  return {
+    kits,
+    meta: {
+      nextCursor,
+      pageSize,
+      totalKits,
+      totalPages,
+    },
+  };
+}
+
+export async function getAllKits(order: SortOrder) {
+  const kits = await prisma.kit.findMany({
+    orderBy: {
+      createdAt: order,
+    },
+    select: kitSelect,
+  });
+  const totalKits = await prisma.kit.count();
+
+  return { kits, totalKits };
+}
+
+/**
+ * 가장 마지막 Kit의 id를 가져와 새로운 Kit의 id를 생성합니다.
+ * Kit 가 없을 경우 0000001을 반환합니다.
+ *
+ * @returns kitId
+ */
+export async function getNewKitId() {
+  const lastKit = await prisma.kit.findFirst({ orderBy: { id: 'desc' }, select: { id: true } });
+  const lastId = lastKit?.id || '0';
+  const kitId = String(Number(lastId) + 1).padStart(7, '0');
+  return kitId;
+}
+
+/**
+ * 리워드 이미지 ID를 받아 블러 처리된 이미지 URL을 반환합니다.
+ *
+ * @param id 리워드 이미지 ID
+ * @returns 블러 처리된 이미지 URL
+ */
+export async function getBlurredImageURL(id: string) {
+  const s3 = new S3Manager();
+  const signedUrl = await s3.getObjectUrl(`tmp/${id}`);
+  const buffer = await fetch(signedUrl).then((res) => res.arrayBuffer());
+  const blurredBuffer = await blurImage(buffer);
+  const blurredUrl = await s3.getPresignedUrl(cuid());
+  await uploadWebp(blurredBuffer, blurredUrl);
+  return blurredUrl;
+}
 
 /**
  * 파일을 S3에 업로드

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: Request) {
       },
       ...userSelect,
     },
-    where: { id: userId },
+    where: { id: userId, deletedAt: null },
   });
 
   return NextResponse.json({ data: user });

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -1,14 +1,32 @@
 import { NextResponse } from 'next/server';
 import { prisma, kitSelect, rallySelect, userSelect } from '@/app/api/lib/prisma';
+import { SortOrder } from '@/app/api/lib/types';
+import { UnauthorizedError } from '@/app/api/lib/errors';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const userId = searchParams.get('userId');
+  const orderParam = searchParams.get('order') || 'desc';
+  const order: SortOrder = orderParam === 'asc' ? 'asc' : 'desc';
 
-  if (!userId) return NextResponse.json({ error: '로그인 해주세요.' }, { status: 401 });
+  if (!userId) return UnauthorizedError;
 
   const user = await prisma.user.findUnique({
-    select: { rallies: { select: rallySelect }, kits: { select: kitSelect }, ...userSelect },
+    select: {
+      rallies: {
+        orderBy: {
+          createdAt: order,
+        },
+        select: rallySelect,
+      },
+      kits: {
+        orderBy: {
+          createdAt: order,
+        },
+        select: kitSelect,
+      },
+      ...userSelect,
+    },
     where: { id: userId },
   });
 

--- a/app/api/my/kits/route.ts
+++ b/app/api/my/kits/route.ts
@@ -1,15 +1,22 @@
 import { NextResponse } from 'next/server';
 import { kitSelect, prisma } from '@/app/api/lib/prisma';
+import { SortOrder } from '@/app/api/lib/types';
+import { UnauthorizedError } from '@/app/api/lib/errors';
 
 // TODO: MVP 이후 페이지네이션 구현
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const userId = searchParams.get('userId');
+  const orderParam = searchParams.get('order') || 'desc';
+  const order: SortOrder = orderParam === 'asc' ? 'asc' : 'desc';
 
-  if (!userId) return NextResponse.json({ error: '로그인 해주세요.' }, { status: 401 });
+  if (!userId) return UnauthorizedError;
 
   const data = await prisma.kit.findMany({
     where: { uploaderId: userId },
+    orderBy: {
+      createdAt: order,
+    },
     select: kitSelect,
   });
 

--- a/app/api/my/kits/route.ts
+++ b/app/api/my/kits/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: Request) {
   if (!userId) return UnauthorizedError;
 
   const data = await prisma.kit.findMany({
-    where: { uploaderId: userId },
+    where: { uploaderId: userId, deletedAt: null },
     orderBy: {
       createdAt: order,
     },

--- a/app/api/my/rallies/route.ts
+++ b/app/api/my/rallies/route.ts
@@ -1,16 +1,25 @@
 import { NextResponse } from 'next/server';
 import { prisma, rallySelect } from '@/app/api/lib/prisma';
 import { MyRally } from '@/types/Rally';
+import { SortOrder } from '@/app/api/lib/types';
+import { UnauthorizedError } from '@/app/api/lib/errors';
 
-// TODO: MVP 이후 페이지네이션, 파람 구현
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const userId = searchParams.get('userId');
+  const orderParam = searchParams.get('order') || 'desc';
+  const order: SortOrder = orderParam === 'asc' ? 'asc' : 'desc';
 
-  if (!userId) return NextResponse.json({ error: '로그인 해주세요.' }, { status: 401 });
+  if (!userId) return UnauthorizedError;
 
   try {
-    const rallies = (await prisma.rally.findMany({ where: { starterId: userId }, select: rallySelect })) satisfies MyRally[];
+    const rallies = (await prisma.rally.findMany({
+      where: { starterId: userId },
+      orderBy: {
+        createdAt: order,
+      },
+      select: rallySelect,
+    })) satisfies MyRally[];
 
     return NextResponse.json({
       data: rallies,

--- a/app/api/my/rallies/route.ts
+++ b/app/api/my/rallies/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: Request) {
 
   try {
     const rallies = (await prisma.rally.findMany({
-      where: { starterId: userId },
+      where: { starterId: userId, deletedAt: null },
       orderBy: {
         createdAt: order,
       },

--- a/app/api/rallies/[id]/extend/route.ts
+++ b/app/api/rallies/[id]/extend/route.ts
@@ -15,7 +15,7 @@ export async function PATCH(request: Request, { params }: PatchRallyParams) {
 
   try {
     const rally = await prisma.rally.findUnique({
-      where: { id: rallyId },
+      where: { id: rallyId, deletedAt: null },
       include: { kit: { include: { _count: { select: { stamps: true } } } } },
     });
 

--- a/app/api/rallies/[id]/extend/route.ts
+++ b/app/api/rallies/[id]/extend/route.ts
@@ -1,0 +1,38 @@
+import { BadRequestError, NotFoundRallyError, ServerError, UnauthorizedError } from '@/app/api/lib/errors';
+import { prisma, rallySelect } from '@/app/api/lib/prisma';
+import { auth } from '@/auth';
+import { NextResponse } from 'next/server';
+type PatchRallyParams = { params: { id: string } };
+
+// NOTE: 랠리 연장 API
+export async function PATCH(request: Request, { params }: PatchRallyParams) {
+  const session = await auth();
+  const currentUser = session?.user;
+
+  const { id: rallyId } = params;
+
+  if (!currentUser) return UnauthorizedError;
+
+  try {
+    const rally = await prisma.rally.findUnique({
+      where: { id: rallyId },
+      include: { kit: { include: { _count: { select: { stamps: true } } } } },
+    });
+
+    if (!rally) return NotFoundRallyError;
+    if (rally.extendedDueDate || !rally.dueDate) return BadRequestError;
+
+    const remainStamp = rally.kit._count.stamps - rally.stampCount;
+    const extendedDueDate = new Date(rally.dueDate);
+
+    extendedDueDate.setDate(extendedDueDate.getDate() + remainStamp);
+
+    const updatedRally = await prisma.rally.update({
+      where: { id: rallyId },
+      data: { extendedDueDate },
+    });
+    return NextResponse.json({ data: updatedRally }, { status: 200 });
+  } catch (error) {
+    return ServerError;
+  }
+}

--- a/app/api/rallies/[id]/route.ts
+++ b/app/api/rallies/[id]/route.ts
@@ -1,16 +1,11 @@
 import { NextResponse } from 'next/server';
-import { auth } from '@/auth';
 import { prisma, rallySelect } from '@/app/api/lib/prisma';
-import { BadRequestError, NotFoundRallyError, ServerError, StampLimitError, UnauthorizedError } from '@/app/api/lib/errors';
-import { getRallyStatus } from '@/app/api/lib/utils';
+import { NotFoundRallyError } from '@/app/api/lib/errors';
 
 type GetRallyParams = { params: { id: string } };
-type PatchRallyParams = { params: { id: string } };
-type PostRallyParams = { params: { id: string } };
 
 export async function GET(_: Request, { params }: GetRallyParams) {
   const { id } = params;
-
   const rally = await prisma.rally.findUnique({
     where: { id },
     select: { ...rallySelect, stampable: true },
@@ -19,58 +14,4 @@ export async function GET(_: Request, { params }: GetRallyParams) {
   if (!rally) return NotFoundRallyError;
 
   return NextResponse.json({ data: rally });
-}
-
-// TODO: 향후 랠리 연장용 API로 수정
-// export async function PATCH(request: Request, { params }: PatchRallyParams) {
-//   const session = await auth();
-//   const currentUser = session?.user;
-
-//   const { id } = params;
-//   const body = await request.json();
-//   const { stampCount } = body;
-
-//   if (!currentUser) return UnauthorizedError;
-
-//   if (stampCount === undefined || typeof stampCount !== 'number' || stampCount < 0) {
-//     return BadRequestError;
-//   }
-//   try {
-//     const status = getRallyStatus(stampCount);
-//     const updatedRally = await prisma.rally.update({
-//       where: { id },
-//       data: { stampCount, status },
-//       select: rallySelect,
-//     });
-
-//     return NextResponse.json({ data: updatedRally }, { status: 200 });
-//   } catch (error) {
-//     return ServerError;
-//   }
-// }
-
-export async function PATCH(_: Request, { params }: PostRallyParams) {
-  const { id: rallyId } = params;
-
-  if (!rallyId) return BadRequestError;
-
-  try {
-    const rally = await prisma.rally.findUnique({
-      where: { id: rallyId },
-      include: { kit: { include: { _count: { select: { stamps: true } } } } },
-    });
-
-    if (!rally) return NotFoundRallyError;
-    if (rally.stampCount >= rally.kit._count.stamps) return StampLimitError;
-
-    const updatedStampCount = rally.stampCount + 1;
-    const updatedRally = await prisma.rally.update({
-      where: { id: rallyId },
-      data: { stampCount: updatedStampCount, status: getRallyStatus(updatedStampCount) },
-    });
-
-    return NextResponse.json(updatedRally);
-  } catch (error) {
-    return ServerError;
-  }
 }

--- a/app/api/rallies/[id]/route.ts
+++ b/app/api/rallies/[id]/route.ts
@@ -13,7 +13,7 @@ export async function GET(_: Request, { params }: GetRallyParams) {
 
   try {
     const rally = (await prisma.rally.findUniqueOrThrow({
-      where: { id },
+      where: { id, deletedAt: null },
       select: { ...rallySelect, stampable: true },
     })) as RallyData;
 
@@ -32,7 +32,7 @@ export async function DELETE(_: Request, { params }: DeleteRallyParams) {
   const { id } = params;
 
   try {
-    const rally = await prisma.rally.findUnique({ where: { id } });
+    const rally = await prisma.rally.findUnique({ where: { id, deletedAt: null } });
 
     if (!rally) NotFoundRallyError;
 

--- a/app/api/rallies/[id]/route.ts
+++ b/app/api/rallies/[id]/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
 import { prisma, rallySelect } from '@/app/api/lib/prisma';
-import { NotFoundRallyError } from '@/app/api/lib/errors';
+import { NotFoundRallyError, ServerError } from '@/app/api/lib/errors';
 
 type GetRallyParams = { params: { id: string } };
+type DeleteRallyParams = { params: { id: string } };
 
 export async function GET(_: Request, { params }: GetRallyParams) {
   const { id } = params;
@@ -14,4 +15,23 @@ export async function GET(_: Request, { params }: GetRallyParams) {
   if (!rally) return NotFoundRallyError;
 
   return NextResponse.json({ data: rally });
+}
+
+export async function DELETE(_: Request, { params }: DeleteRallyParams) {
+  const { id } = params;
+
+  try {
+    const rally = await prisma.rally.findUnique({ where: { id } });
+
+    if (!rally) NotFoundRallyError;
+
+    const deletedRally = await prisma.rally.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+
+    return NextResponse.json({ data: deletedRally }, { status: 200 });
+  } catch (error) {
+    return ServerError;
+  }
 }

--- a/app/api/rallies/[id]/route.ts
+++ b/app/api/rallies/[id]/route.ts
@@ -13,7 +13,7 @@ export async function GET(_: Request, { params }: GetRallyParams) {
 
   const rally = await prisma.rally.findUnique({
     where: { id },
-    select: rallySelect,
+    select: { ...rallySelect, stampable: true },
   });
 
   if (!rally) return NotFoundRallyError;

--- a/app/api/rallies/[id]/stamp/route.ts
+++ b/app/api/rallies/[id]/stamp/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/app/api/lib/prisma';
+import { BadRequestError, NotFoundRallyError, ServerError, StampLimitError } from '@/app/api/lib/errors';
+import { getRallyStatus } from '@/app/api/lib/utils';
+
+type PatchRallyParams = { params: { id: string } };
+
+export async function PATCH(_: Request, { params }: PatchRallyParams) {
+  const { id: rallyId } = params;
+
+  if (!rallyId) return BadRequestError;
+
+  try {
+    const rally = await prisma.rally.findUnique({
+      where: { id: rallyId },
+      include: { kit: { include: { _count: { select: { stamps: true } } } } },
+    });
+
+    if (!rally) return NotFoundRallyError;
+    if (rally.stampCount >= rally.kit._count.stamps) return StampLimitError;
+
+    const updatedStampCount = rally.stampCount + 1;
+    const updatedRally = await prisma.rally.update({
+      where: { id: rallyId },
+      data: { stampCount: updatedStampCount, status: getRallyStatus(updatedStampCount), lastStampDate: new Date() },
+    });
+
+    return NextResponse.json(updatedRally);
+  } catch (error) {
+    return ServerError;
+  }
+}

--- a/app/api/rallies/[id]/stamp/route.ts
+++ b/app/api/rallies/[id]/stamp/route.ts
@@ -1,13 +1,17 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/app/api/lib/prisma';
-import { BadRequestError, NotFoundRallyError, ServerError, StampLimitError } from '@/app/api/lib/errors';
+import { BadRequestError, NotFoundRallyError, ServerError, StampLimitError, UnauthorizedError } from '@/app/api/lib/errors';
 import { getRallyStatus } from '@/app/api/lib/utils';
+import { auth } from '@/auth';
 
 type PatchRallyParams = { params: { id: string } };
 
 export async function PATCH(_: Request, { params }: PatchRallyParams) {
+  const session = await auth();
+  const currentUser = session?.user;
   const { id: rallyId } = params;
 
+  if (!currentUser) return UnauthorizedError;
   if (!rallyId) return BadRequestError;
 
   try {
@@ -20,9 +24,15 @@ export async function PATCH(_: Request, { params }: PatchRallyParams) {
     if (rally.stampCount >= rally.kit._count.stamps) return StampLimitError;
 
     const updatedStampCount = rally.stampCount + 1;
+    const isRallyComplete = rally.stampCount === rally.kit._count.stamps;
     const updatedRally = await prisma.rally.update({
       where: { id: rallyId },
-      data: { stampCount: updatedStampCount, status: getRallyStatus(updatedStampCount), lastStampDate: new Date() },
+      data: {
+        stampCount: updatedStampCount,
+        status: getRallyStatus(updatedStampCount),
+        lastStampDate: new Date(),
+        completionDate: isRallyComplete ? new Date() : null,
+      },
     });
 
     return NextResponse.json(updatedRally);

--- a/app/api/rallies/[id]/stamp/route.ts
+++ b/app/api/rallies/[id]/stamp/route.ts
@@ -16,7 +16,7 @@ export async function PATCH(_: Request, { params }: PatchRallyParams) {
 
   try {
     const rally = await prisma.rally.findUnique({
-      where: { id: rallyId },
+      where: { id: rallyId, deletedAt: null },
       include: { kit: { include: { _count: { select: { stamps: true } } } } },
     });
 

--- a/app/api/rallies/route.ts
+++ b/app/api/rallies/route.ts
@@ -1,14 +1,13 @@
 import { NextResponse } from 'next/server';
 import { prisma, kitSelect, userSelect } from '@/app/api/lib/prisma';
+import { BadRequestError, ServerError } from '../lib/errors';
 
 export async function POST(request: Request) {
   // TODO: auth, 필수 항목 검증 미들웨어 구현
   const body = await request.json();
   const { title, description, kitId, starterId } = body;
 
-  if (!title || !kitId || !starterId) {
-    return NextResponse.json({ error: '요청이 유효하지 않습니다.' }, { status: 400 });
-  }
+  if (!title || !kitId || !starterId) return BadRequestError;
 
   try {
     const newRally = await prisma.rally.create({
@@ -32,6 +31,6 @@ export async function POST(request: Request) {
     return NextResponse.json({ data: newRally }, { status: 201 });
   } catch (error) {
     console.log('error', error);
-    return NextResponse.json({ error: '예기치 못한 에러가 발생했습니다.' }, { status: 500 });
+    return ServerError;
   }
 }


### PR DESCRIPTION
## 작업 내용

관련 이슈: #186 

## 테스트 내용

- [x] deletedAt이 null이 아닌 값은 반환하지 않습니다.
  - [x] kit
  - [x] rally
- [x] rallies/[id]에서 stampable 값을 반환합니다.
- [x] 랠리 화면에서 스탬프를 정상적으로 찍을 수 있습니다.

### 리뷰어에게
#### 리뷰하기 전
- 셀프리뷰를 날려가면서 해서 피드백 사항이 많을 수 있습니다 ㅠㅠ
- 로컬에서 꼭!! 동작 확인 부탁드립니다.
- `npx prisma generate` 실행 후 로컬 리뷰 해주세요.
- 미들웨어로 소프트 딜리트를 구현할 수 있는걸 나중에 알았습니다...ㅠ 나중에 여력이 되면 검토 후 수정해보겠습니다. (https://www.prisma.io/docs/orm/prisma-client/client-extensions/middleware/soft-delete-middleware)
- 가급적이면 라우터에서는 로직을 최소화할 수 있도록 내부 함수는 전부 유틸로 빼는 리팩토링을 함께 진행했습니다.

#### 리뷰 후
없음

### 체크리스트

- [x] 리뷰하는데 20분 이상 필요한가요? -> 꼭!! 로컬 확인 부탁드립니다!
- [x] 셀프 리뷰를 진행했습니다.
- [x] 커밋 메세지를 컨벤션에 맞게 작성했습니다.
- [x] 테스트 내용에 기재된 항목에 대해서 실제로 테스트를 진행하고 동작을 확인했습니다.
