### PR TITLE
#169 랠리 생성 페이지 기한 입력 컴포넌트 작성

### DIFF
--- a/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/ModalContent.tsx
+++ b/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/ModalContent.tsx
@@ -23,7 +23,7 @@ export default function DeadlineModalContent({ setOpen, setValue }: DeadlineModa
     <Card className="border-none shadow-none flex flex-col gap-6">
       <CardHeader className="flex flex-col justify-start items-start">
         <CardTitle className="text-base">완주 기한을 선택하세요.</CardTitle>
-        <CardDescription className="text-left">완주 기한까지 완주하지 못하면 랠리를 더 이상 진행할 수 없습니다.</CardDescription>
+        <CardDescription className="text-left">설정한 기한까지 완주하지 못하면 랠리를 더 이상 진행할 수 없습니다.</CardDescription>
       </CardHeader>
       <CardContent>
         <Picker value={pickerValue} setValue={setPickerValue} today={today} durings={durings} months={months} datesByMonth={datesByMonth} />

--- a/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/ModalContent.tsx
+++ b/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/ModalContent.tsx
@@ -1,0 +1,47 @@
+import { useState, Dispatch, SetStateAction } from 'react';
+import { UseFormSetValue } from 'react-hook-form';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import Picker from './Picker';
+import { convertToDeadline, getDeadlineInfo } from './lib';
+import { FormValues } from '../types';
+
+interface DeadlineModalProps {
+  setOpen: Dispatch<SetStateAction<boolean>>;
+  setValue: UseFormSetValue<FormValues>;
+}
+
+export default function DeadlineModalContent({ setOpen, setValue }: DeadlineModalProps) {
+  const { today, durings, datesByMonth, months } = getDeadlineInfo();
+  const [pickerValue, setPickerValue] = useState({
+    during: durings[0],
+    month: months[0],
+    date: datesByMonth[months[0]][0],
+  });
+
+  return (
+    <Card className="border-none shadow-none flex flex-col gap-6">
+      <CardHeader className="flex flex-col justify-start items-start p-0">
+        <CardTitle className="text-base">완주 기한을 선택하세요.</CardTitle>
+        <CardDescription className="text-left">완주 기한까지 완주하지 못하면 랠리를 더 이상 진행할 수 없습니다.</CardDescription>
+      </CardHeader>
+      <CardContent className="p-0">
+        <Picker value={pickerValue} setValue={setPickerValue} today={today} durings={durings} months={months} datesByMonth={datesByMonth} />
+      </CardContent>
+      <CardFooter className="flex justify-stretch gap-2 p-0">
+        <Button variant="outline" className="flex-1" onClick={() => setOpen(false)}>
+          취소하기
+        </Button>
+        <Button
+          className="flex-1"
+          onClick={() => {
+            setValue('deadline', convertToDeadline(today)(pickerValue));
+            setOpen(false);
+          }}
+        >
+          기한설정
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/ModalContent.tsx
+++ b/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/ModalContent.tsx
@@ -21,14 +21,14 @@ export default function DeadlineModalContent({ setOpen, setValue }: DeadlineModa
 
   return (
     <Card className="border-none shadow-none flex flex-col gap-6">
-      <CardHeader className="flex flex-col justify-start items-start p-0">
+      <CardHeader className="flex flex-col justify-start items-start">
         <CardTitle className="text-base">완주 기한을 선택하세요.</CardTitle>
         <CardDescription className="text-left">완주 기한까지 완주하지 못하면 랠리를 더 이상 진행할 수 없습니다.</CardDescription>
       </CardHeader>
-      <CardContent className="p-0">
+      <CardContent>
         <Picker value={pickerValue} setValue={setPickerValue} today={today} durings={durings} months={months} datesByMonth={datesByMonth} />
       </CardContent>
-      <CardFooter className="flex justify-stretch gap-2 p-0">
+      <CardFooter className="flex justify-stretch gap-2">
         <Button variant="outline" className="flex-1" onClick={() => setOpen(false)}>
           취소하기
         </Button>

--- a/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/Picker.tsx
+++ b/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/Picker.tsx
@@ -1,0 +1,48 @@
+import { Dispatch, SetStateAction } from 'react';
+import Picker from 'react-mobile-picker';
+import { syncPickerValue } from './lib';
+import { DeadlinePickerValue } from './types';
+import { cn } from '@/lib/utils';
+
+interface DeadlinePickerProps {
+  value: DeadlinePickerValue;
+  setValue: Dispatch<SetStateAction<DeadlinePickerValue>>;
+  today: Date;
+  durings: string[];
+  months: string[];
+  datesByMonth: Record<string, string[]>;
+}
+
+const styles = {
+  options: 'text-grey-100 font-bold',
+  selected: 'text-primary',
+};
+
+export default function DeadlinePicker({ value, setValue, today, durings, months, datesByMonth }: DeadlinePickerProps) {
+  return (
+    <Picker value={value} onChange={(unSynced) => setValue(syncPickerValue(today)(unSynced))} wheelMode="normal" height={108}>
+      <Picker.Column name="during">
+        {durings.map((option) => (
+          <Picker.Item key={option} value={option} className={cn(styles.options, { [styles.selected]: option === value.during })}>
+            {option}일동안{(option === value.during && console.log(styles.selected)) || ''}
+          </Picker.Item>
+        ))}
+      </Picker.Column>
+      <Picker.Column name="month">
+        {months.map((option) => (
+          <Picker.Item key={option} value={option} className={cn(styles.options, { [styles.selected]: option === value.month })}>
+            {option}월
+          </Picker.Item>
+        ))}
+      </Picker.Column>
+
+      <Picker.Column name="date">
+        {datesByMonth[value.month]?.map((option) => (
+          <Picker.Item key={option} value={option} className={cn(styles.options, { [styles.selected]: option === value.date })}>
+            {option}일
+          </Picker.Item>
+        ))}
+      </Picker.Column>
+    </Picker>
+  );
+}

--- a/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/index.tsx
+++ b/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/index.tsx
@@ -38,7 +38,7 @@ export default function DeadlineField({ control, setValue }: DeadlineFieldProps)
           </FormControl>
           <FormDescription>
             완주 기한 설정시 난이도가 매우 올라가게 됩니다.
-            <Modal open={open}>
+            <Modal open={open} className="p-0">
               <DeadlineModalContent setOpen={setOpen} setValue={setValue} />
             </Modal>
           </FormDescription>

--- a/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/index.tsx
+++ b/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/index.tsx
@@ -24,13 +24,15 @@ export default function DeadlineField({ control, setValue }: DeadlineFieldProps)
           <FormLabel>
             완주 기한
             <span className="font-normal text-xs text-gray-400">(최소 일주일 이후 부터 설정 가능)</span>
-            <div className="relative">
+            <div className="relative font-normal">
               <Input placeholder="완주 기한 설정하기" value={presentDeadline(value)} onClick={() => setOpen(true)} />
-              <XIcon
-                className="absolute [transform:translate(-50%,-50%)] right-1 top-1/2 size-4 p-0.5 rounded-full bg-grey-100 text-background"
-                onClick={() => setValue('deadline', undefined)}
-                type="button"
-              />
+              {value && (
+                <XIcon
+                  className="absolute [transform:translate(-50%,-50%)] right-1 top-1/2 size-4 p-0.5 rounded-full bg-grey-100 text-background"
+                  onClick={() => setValue('deadline', undefined)}
+                  type="button"
+                />
+              )}
             </div>
           </FormLabel>
           <FormControl>

--- a/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/index.tsx
+++ b/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/index.tsx
@@ -39,7 +39,7 @@ export default function DeadlineField({ control, setValue }: DeadlineFieldProps)
             <Input className="hidden" {...field} value={inputDeadline(value)} />
           </FormControl>
           <FormDescription>
-            완주 기한 설정시 난이도가 매우 올라가게 됩니다.
+            설정한 기한까지 완주하지 못하면 랠리를 더 이상 진행할 수 없습니다.
             <Modal open={open} className="p-0">
               <DeadlineModalContent setOpen={setOpen} setValue={setValue} />
             </Modal>

--- a/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/index.tsx
+++ b/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/index.tsx
@@ -1,14 +1,12 @@
+import { XIcon } from 'lucide-react';
 import { useState } from 'react';
 import type { UseFormSetValue } from 'react-hook-form';
 import Modal from '@/components/Modal';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { convertToDeadline, getDeadlineInfo, inputDeadline, presentDeadline } from './lib';
 import { FormFieldProps, FormValues } from '../types';
-import Picker from './Picker';
-import { XIcon } from 'lucide-react';
+import { inputDeadline, presentDeadline } from './lib';
+import DeadlineModalContent from './ModalContent';
 
 interface DeadlineFieldProps extends FormFieldProps {
   setValue: UseFormSetValue<FormValues>;
@@ -16,12 +14,6 @@ interface DeadlineFieldProps extends FormFieldProps {
 
 export default function DeadlineField({ control, setValue }: DeadlineFieldProps) {
   const [open, setOpen] = useState(false);
-  const { today, durings, datesByMonth, months } = getDeadlineInfo();
-  const [pickerValue, setPickerValue] = useState({
-    during: durings[0],
-    month: months[0],
-    date: datesByMonth[months[0]][0],
-  });
 
   return (
     <FormField
@@ -47,29 +39,7 @@ export default function DeadlineField({ control, setValue }: DeadlineFieldProps)
           <FormDescription>
             완주 기한 설정시 난이도가 매우 올라가게 됩니다.
             <Modal open={open}>
-              <Card className="border-none shadow-none flex flex-col gap-6">
-                <CardHeader className="flex flex-col justify-start items-start p-0">
-                  <CardTitle className="text-base">완주 기한을 선택하세요.</CardTitle>
-                  <CardDescription className="text-left">완주 기한까지 완주하지 못하면 랠리를 더 이상 진행할 수 없습니다.</CardDescription>
-                </CardHeader>
-                <CardContent className="p-0">
-                  <Picker value={pickerValue} setValue={setPickerValue} today={today} durings={durings} months={months} datesByMonth={datesByMonth} />
-                </CardContent>
-                <CardFooter className="flex justify-stretch gap-2 p-0">
-                  <Button variant="outline" className="flex-1" onClick={() => setOpen(false)}>
-                    취소하기
-                  </Button>
-                  <Button
-                    className="flex-1"
-                    onClick={() => {
-                      setValue('deadline', convertToDeadline(today)(pickerValue));
-                      setOpen(false);
-                    }}
-                  >
-                    기한설정
-                  </Button>
-                </CardFooter>
-              </Card>
+              <DeadlineModalContent setOpen={setOpen} setValue={setValue} />
             </Modal>
           </FormDescription>
           <FormMessage />

--- a/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/index.tsx
+++ b/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/index.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import type { UseFormSetValue } from 'react-hook-form';
+import Modal from '@/components/Modal';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { convertToDeadline, getDeadlineInfo, inputDeadline, presentDeadline } from './lib';
+import { FormFieldProps, FormValues } from '../types';
+import Picker from './Picker';
+import { XIcon } from 'lucide-react';
+
+interface DeadlineFieldProps extends FormFieldProps {
+  setValue: UseFormSetValue<FormValues>;
+}
+
+export default function DeadlineField({ control, setValue }: DeadlineFieldProps) {
+  const [open, setOpen] = useState(false);
+  const { today, durings, datesByMonth, months } = getDeadlineInfo();
+  const [pickerValue, setPickerValue] = useState({
+    during: durings[0],
+    month: months[0],
+    date: datesByMonth[months[0]][0],
+  });
+
+  return (
+    <FormField
+      control={control}
+      name="deadline"
+      render={({ field: { value, ...field } }) => (
+        <FormItem>
+          <FormLabel>
+            완주 기한
+            <span className="font-normal text-xs text-gray-400">(최소 일주일 이후 부터 설정 가능)</span>
+          </FormLabel>
+          <FormControl>
+            <Input className="hidden" {...field} value={inputDeadline(value)} />
+          </FormControl>
+          <span className="relative">
+            <Input placeholder="완주 기한 설정하기" value={presentDeadline(value)} onClick={() => setOpen(true)} />
+            <XIcon
+              className="absolute right-2 bottom-3 size-4 p-0.5 rounded-full bg-grey-100 text-background"
+              onClick={() => setValue('deadline', undefined)}
+              type="button"
+            />
+          </span>
+          <FormDescription>
+            완주 기한 설정시 난이도가 매우 올라가게 됩니다.
+            <Modal open={open}>
+              <Card className="border-none shadow-none flex flex-col gap-6">
+                <CardHeader className="flex flex-col justify-start items-start p-0">
+                  <CardTitle className="text-base">완주 기한을 선택하세요.</CardTitle>
+                  <CardDescription className="text-left">완주 기한까지 완주하지 못하면 랠리를 더 이상 진행할 수 없습니다.</CardDescription>
+                </CardHeader>
+                <CardContent className="p-0">
+                  <Picker value={pickerValue} setValue={setPickerValue} today={today} durings={durings} months={months} datesByMonth={datesByMonth} />
+                </CardContent>
+                <CardFooter className="flex justify-stretch gap-2 p-0">
+                  <Button variant="outline" className="flex-1" onClick={() => setOpen(false)}>
+                    취소하기
+                  </Button>
+                  <Button
+                    className="flex-1"
+                    onClick={() => {
+                      setValue('deadline', convertToDeadline(today)(pickerValue));
+                      setOpen(false);
+                    }}
+                  >
+                    기한설정
+                  </Button>
+                </CardFooter>
+              </Card>
+            </Modal>
+          </FormDescription>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}

--- a/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/index.tsx
+++ b/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/index.tsx
@@ -24,18 +24,18 @@ export default function DeadlineField({ control, setValue }: DeadlineFieldProps)
           <FormLabel>
             완주 기한
             <span className="font-normal text-xs text-gray-400">(최소 일주일 이후 부터 설정 가능)</span>
+            <div className="relative">
+              <Input placeholder="완주 기한 설정하기" value={presentDeadline(value)} onClick={() => setOpen(true)} />
+              <XIcon
+                className="absolute [transform:translate(-50%,-50%)] right-1 top-1/2 size-4 p-0.5 rounded-full bg-grey-100 text-background"
+                onClick={() => setValue('deadline', undefined)}
+                type="button"
+              />
+            </div>
           </FormLabel>
           <FormControl>
             <Input className="hidden" {...field} value={inputDeadline(value)} />
           </FormControl>
-          <span className="relative">
-            <Input placeholder="완주 기한 설정하기" value={presentDeadline(value)} onClick={() => setOpen(true)} />
-            <XIcon
-              className="absolute right-2 bottom-3 size-4 p-0.5 rounded-full bg-grey-100 text-background"
-              onClick={() => setValue('deadline', undefined)}
-              type="button"
-            />
-          </span>
           <FormDescription>
             완주 기한 설정시 난이도가 매우 올라가게 됩니다.
             <Modal open={open}>

--- a/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/lib.ts
+++ b/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/lib.ts
@@ -1,0 +1,65 @@
+import { entries, evolve, fromEntries, groupBy, join, keys, map, pipe, range, toArray } from '@fxts/core';
+import { ap, derive } from '@/lib/utils';
+import * as E from '@/lib/either';
+import { MAX_RALLY_DEADLINE_DAYS, MIN_RALLY_DEADLINE_DAYS } from '@/lib/constants';
+import { addYear, convertMsToDate, diffDates, getDate, addDate, getMonth, getYear, isOlderThan, pad02, dateToArray, now } from '@/lib/date';
+import { DeadlinePickerValue, ParsedMonthDate } from './types';
+
+export const isDeadlineValid = (today: Date) => (date: Date) => geMinDeadline(today)(date) && leMaxDeadline(today)(date);
+const geMinDeadline = (today: Date) => (date: Date) => convertMsToDate(diffDates(today)(date)) >= MIN_RALLY_DEADLINE_DAYS;
+const leMaxDeadline = (today: Date) => (date: Date) => convertMsToDate(diffDates(today)(date)) <= MAX_RALLY_DEADLINE_DAYS;
+
+export const presentDeadline = (date?: Date) => (date === undefined ? '' : pipe(dateToArray(date), map(pad02), join(' - ')) + ' 까지');
+export const inputDeadline = (date?: Date) => (date === undefined ? '' : pipe(dateToArray(date), join('-')));
+export const convertToDeadline =
+  (since: Date) =>
+  (picker: DeadlinePickerValue): Date =>
+    pipe(picker, getSameYearTargetDate(since), addYearIfOlderThan(since));
+
+const stringifyMonth = (date: Date) => pipe(date, getMonth, String);
+const parseMonth = (month: string) => parseInt(month) - 1;
+const stringifyDate = (date: Date) => pipe(date, getDate, String);
+const stringifyMonthDate = (date: Date) => ({
+  month: stringifyMonth(date),
+  date: stringifyDate(date),
+});
+const formatDates = ([k, v]: [string, Date[]]) => [k, pipe(v, map(stringifyDate), toArray)] as const;
+const getDurings = (days: number[]) => pipe(days, map(String), toArray);
+const getDates = (today: Date) => (days: number[]) => pipe(days, map(addDate), map(ap(today)), toArray);
+const getDatesByMonth = (dates: Date[]) => pipe(dates, groupBy(stringifyMonth), entries, map(formatDates), fromEntries);
+const getMonths = (datesByMonth: Record<string, string[]>) => pipe(datesByMonth, keys, toArray);
+const getDuring = (since: Date) => (until: Date) => pipe(until, diffDates(since), convertMsToDate, String);
+export const getDeadlineInfo = () =>
+  pipe(
+    {},
+    derive('today')(now),
+    derive('days')(() => toArray(range(MIN_RALLY_DEADLINE_DAYS, MAX_RALLY_DEADLINE_DAYS + 1))),
+    derive('durings')(({ days }) => getDurings(days)),
+    derive('dates')(({ today, days }) => getDates(today)(days)),
+    derive('datesByMonth')(({ dates }) => getDatesByMonth(dates)),
+    derive('months')(({ datesByMonth }) => getMonths(datesByMonth)),
+  );
+const parseTargetDate: (target: DeadlinePickerValue) => ParsedMonthDate = evolve({
+  date: parseInt,
+  month: parseMonth,
+});
+const addYearIfOlderThan = (since: Date) => (target: Date) => pipe(target, E.lift(isOlderThan(since)), E.map(addYear(1)), E.pop);
+const dateFromMonthDate =
+  (year: number) =>
+  ({ month, date }: ParsedMonthDate) =>
+    new Date(year, month, date);
+const getSameYearTargetDate = (since: Date) => (rawTarget: DeadlinePickerValue) =>
+  pipe(rawTarget, parseTargetDate, dateFromMonthDate(getYear(since)));
+const syncDuring = (since: Date) => (until: DeadlinePickerValue) =>
+  pipe(until, getSameYearTargetDate(since), addYearIfOlderThan(since), getDuring(since));
+
+const syncMonthDate =
+  (since: Date) =>
+  ({ during }: DeadlinePickerValue) =>
+    pipe(during, Number, addDate, ap(since), stringifyMonthDate);
+const updateMonthDate = (since: Date) => (unSynced: DeadlinePickerValue) => ({ ...unSynced, ...syncMonthDate(since)(unSynced) });
+const updateDuring = (since: Date) => (unSynced: DeadlinePickerValue) => ({ ...unSynced, during: syncDuring(since)(unSynced) });
+const isDuringUpdated = (prev: DeadlinePickerValue) => (unSynced: DeadlinePickerValue) => prev.during === unSynced.during;
+
+export const syncPickerValue = (since: Date) => (unSynced: DeadlinePickerValue) => (prev: DeadlinePickerValue) =>
+  pipe(unSynced, E.lift(isDuringUpdated(prev)), E.match(updateMonthDate(since), updateDuring(since)));

--- a/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/types.ts
+++ b/app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/types.ts
@@ -1,0 +1,9 @@
+export type DeadlinePickerValue = {
+  during: string;
+  month: string;
+  date: string;
+};
+export interface ParsedMonthDate {
+  month: number;
+  date: number;
+}

--- a/app/(back)/kits/[id]/start/components/RallyStartForm/index.tsx
+++ b/app/(back)/kits/[id]/start/components/RallyStartForm/index.tsx
@@ -7,6 +7,7 @@ import { Form } from '@/components/ui/form';
 import formSchema from './schema';
 import type { FormValues } from './types';
 import TitleField from './TitleField';
+import DeadlineField from './DeadlineField';
 import DescriptionField from './DescriptionField';
 import SubmitButton from './Submit';
 
@@ -49,6 +50,7 @@ export default function RallyStartForm({ starterId, kitId }: RallyStartFormProps
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-15">
         <TitleField control={form.control} />
+        <DeadlineField control={form.control} setValue={form.setValue} />
         <DescriptionField control={form.control} />
         <SubmitButton state={form.formState} />
       </form>

--- a/app/(back)/kits/[id]/start/components/RallyStartForm/schema.ts
+++ b/app/(back)/kits/[id]/start/components/RallyStartForm/schema.ts
@@ -1,4 +1,7 @@
+import { now } from '@/lib/date';
+import { isDeadlineValid } from './DeadlineField/lib';
 import { z } from 'zod';
+import { MAX_RALLY_DEADLINE_DAYS, MIN_RALLY_DEADLINE_DAYS } from '@/lib/constants';
 
 const formSchema = z
   .object({
@@ -12,6 +15,12 @@ const formSchema = z
       .max(20, {
         message: '랠리 목표는 20글자 이하이어야 합니다.',
       }),
+    deadline: z
+      .date()
+      .refine(isDeadlineValid(now()), {
+        message: `완주 기한은 ${MIN_RALLY_DEADLINE_DAYS}일 이상 ${MAX_RALLY_DEADLINE_DAYS}일 이하이어야 합니다.`,
+      })
+      .optional(),
     description: z.string().max(200, {
       message: '랠리 설명은 200글자 이하이어야 합니다.',
     }),

--- a/app/api/rallies/route.ts
+++ b/app/api/rallies/route.ts
@@ -4,7 +4,8 @@ import { prisma, kitSelect, userSelect } from '@/app/api/lib/prisma';
 export async function POST(request: Request) {
   // TODO: auth, 필수 항목 검증 미들웨어 구현
   const body = await request.json();
-  const { title, description, kitId, starterId } = body;
+  const { title, description, kitId, starterId, deadline } = body;
+  const dueDate = deadline ? new Date(deadline) : null;
 
   if (!title || !kitId || !starterId) {
     return NextResponse.json({ error: '요청이 유효하지 않습니다.' }, { status: 400 });
@@ -19,7 +20,7 @@ export async function POST(request: Request) {
         kitId,
         starterId,
         stampCount: 0,
-        updatedAt: new Date(),
+        dueDate,
       },
       include: {
         kit: { select: kitSelect },

--- a/components/Modal/index.tsx
+++ b/components/Modal/index.tsx
@@ -1,8 +1,12 @@
-export default function Modal({ children, open }: { children: React.ReactNode; open: boolean }) {
+import { cn } from '@/lib/utils';
+
+export interface ModalProps extends React.DetailedHTMLProps<React.DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement> {}
+
+export default function Modal({ children, open, className }: ModalProps) {
   if (!open) return null;
   return (
     <dialog className={styles.dialog}>
-      <section className={styles.section}>{children}</section>
+      <section className={cn(styles.section, className)}>{children}</section>
     </dialog>
   );
 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -9,6 +9,8 @@ export const AUTO_TWEET = encodeURI('제가 만든 키트로 릴레이를 시작
 export const AUTO_TWEET_HASHTAGS = '꾹꾹,kookkook';
 export const MAXIMUM_TAGS = 6;
 export const API_URL = process.env.API_URL!;
+export const MIN_RALLY_DEADLINE_DAYS = 7;
+export const MAX_RALLY_DEADLINE_DAYS = 100;
 
 export const REGION = process.env.AWS_REGION!;
 export const ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID!;

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,12 +1,24 @@
-import { curry, map, pipe, join } from '@fxts/core';
+import { map, pipe, join } from '@fxts/core';
 import { DATE_TO_MS } from './constants';
+import { ap } from './utils';
 
-const pad02 = (num: number) => num.toString().padStart(2, '0');
+export const pad02 = (num: number) => num.toString().padStart(2, '0');
 export const displayDateYyMmDd = (date: Date) => pipe(date, getDateNumbers, map(pad02), join('.'));
 export const getDateNumbers = (date: Date) => [date.getFullYear(), date.getMonth() + 1, date.getDate()];
-export const convertMsToDate = (ms: number) => Math.floor(ms / DATE_TO_MS);
+export const convertMsToDate = (ms: number) => Math.ceil(ms / DATE_TO_MS);
 export const now = () => new Date();
 export const diffDates = (date1: Date) => (date2: Date) => Math.abs(date1.getTime() - date2.getTime());
 
 export const parseDate = (a: number | string | Date) => new Date(a);
 export const parseNullableDate = (a: number | string | Date | null) => (a ? parseDate(a) : null);
+
+export const getYear = (date: Date) => date.getFullYear();
+export const getMonth = (date: Date) => date.getMonth() + 1;
+export const getDate = (date: Date) => date.getDate();
+export const dateToArray = (date: Date) => pipe([getYear, getMonth, getDate], map(ap(date)));
+export const addDate = (days: number) => (since: Date) => new Date(since.getTime() + days * DATE_TO_MS);
+export const getLastDayOfMonth = (date: Date) => getDate(new Date(getYear(date), getMonth(date), 0));
+export const isOlderThan = (a: Date) => (b: Date) => a.getTime() > b.getTime();
+export const isNewerThan = (a: Date) => (b: Date) => a.getTime() < b.getTime();
+export const addYear = (add: number) => (date: Date) => new Date(date.getFullYear() + add, date.getMonth(), date.getDate());
+export const curryDate = (year: number) => (month: number) => (date: number) => new Date(year, month, date);

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.51.4",
+    "react-mobile-picker": "^1.0.0",
     "sharp": "^0.33.4",
     "sonner": "^1.5.0",
     "swr": "^2.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5243,6 +5243,11 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-mobile-picker@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-mobile-picker/-/react-mobile-picker-1.0.0.tgz#3cd85820865131406fd8f25da48e2533d88d1315"
+  integrity sha512-6xaEBdy4YzgCULRqKcYCa/T34OFRrxXQz8TYrTeRPjq8UEsuH023OpcajnxWbU4X9+kk0nbarorvMFsiaBmXHg==
+
 react-remove-scroll-bar@^2.3.3:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz#3e585e9d163be84a010180b18721e851ac81a29c"


### PR DESCRIPTION
## 작업 내용

관련 이슈: #169 
랠리 생성 시 기한이 입력됩니다.

## 테스트 내용

- [ ] 랠리 생성 페이지에 기한 입력 컴포넌트가 존재합니다.
  <img width="497" alt="image" src="https://github.com/ZZIPSA/kkuk-kkuk-fe/assets/61987505/605cd6ba-baad-48cc-8c16-818319aeca4b">
- [ ] 기한이 입력되면 입력한 기한이 보입니다.
  - [ ] 기한이 입력되면 기한 제거 버튼이 보입니다.
  <img width="492" alt="image" src="https://github.com/ZZIPSA/kkuk-kkuk-fe/assets/61987505/500a1a37-6f6b-4f98-a509-44ee7673083b">
- [ ] 입력 컴포넌트를 클릭하면 입력 모달이 열립니다.
  <img width="364" alt="image" src="https://github.com/ZZIPSA/kkuk-kkuk-fe/assets/61987505/baeb2359-fc23-4b61-aaa9-492f3a407f07">


### 리뷰어에게
#### 리뷰하기 전
- 실행하기 전 `yarn install` 를 실행해 주세요. `picker` 를 위해 react-mobile-picker 라는 패키지를 설치했습니다. 
- `app/(back)/kits/[id]/start/components/RallyStartForm/DeadlineField/index.tsx` 를 기준으로 동일한 경로에 있는 파일 위주로 리뷰 부탁드립니다.

### 체크리스트

- [ ] 리뷰하는데 20분 이상 필요한가요? _20분 초과할 경우, 예상 리뷰 시간을 덧붙여주세요_
- [x] 셀프 리뷰를 진행했습니다.
- [x] 커밋 메세지를 컨벤션에 맞게 작성했습니다.
- [x] 테스트 내용에 기재된 항목에 대해서 실제로 테스트를 진행하고 동작을 확인했습니다.
