### PR TITLE
완주 후 랠리 보상 이미지가 원본 이미지로 표현되도록 변경

### DIFF
--- a/app/(back)/rallies/[id]/components/RallyStamps.tsx
+++ b/app/(back)/rallies/[id]/components/RallyStamps.tsx
@@ -6,16 +6,19 @@ import { addStampPropsByIndex } from './lib';
 
 interface RallyStampsProps extends RallyStampsInfo {
   stamps: RallyPreviewStamp[];
+  completionDate: Date | null;
+  rewardImage: string;
 }
 
-export default function RallyStamps({ stamps, total, count, owned, stampable }: RallyStampsProps) {
+export default function RallyStamps({ stamps, total, count, owned, stampable, rewardImage, completionDate }: RallyStampsProps) {
   return (
     <article className={rallyStampsStyles.container}>
       <h2 className={rallyStampsStyles.title}>스탬프 랠리</h2>
       <section className={rallyStampsStyles.stamps}>
-        {stamps.map(addStampPropsByIndex({ owned, count, total, stampable })).map(({ id, objectKey, status, kind, owned }) => (
-          <RallyStamp key={id} id={id} objectKey={objectKey} status={status} kind={kind} owned={owned} />
-        ))}
+        {stamps.map(addStampPropsByIndex({ owned, count, total, stampable })).map(({ id, objectKey, status, kind, owned }, index) => {
+          if (index === total - 1 && completionDate) objectKey = rewardImage;
+          return <RallyStamp key={id} id={id} objectKey={objectKey} status={status} kind={kind} owned={owned} />;
+        })}
       </section>
     </article>
   );

--- a/app/(back)/rallies/[id]/components/RallyStamps.tsx
+++ b/app/(back)/rallies/[id]/components/RallyStamps.tsx
@@ -1,4 +1,4 @@
-import { RallyStamp } from '@/components/RallyStamp';
+import { RallyStamp, StampKind } from '@/components/RallyStamp';
 import { RallyPreviewStamp } from '@/types/Stamp';
 import { rallyStampsStyles } from './styles';
 import { RallyStampsInfo } from './types';
@@ -16,7 +16,7 @@ export default function RallyStamps({ stamps, total, count, owned, stampable, re
       <h2 className={rallyStampsStyles.title}>스탬프 랠리</h2>
       <section className={rallyStampsStyles.stamps}>
         {stamps.map(addStampPropsByIndex({ owned, count, total, stampable })).map(({ id, objectKey, status, kind, owned }, index) => {
-          if (index === total - 1 && completionDate) objectKey = rewardImage;
+          if (kind === StampKind.reward && completionDate) objectKey = rewardImage;
           return <RallyStamp key={id} id={id} objectKey={objectKey} status={status} kind={kind} owned={owned} />;
         })}
       </section>

--- a/app/(back)/rallies/[id]/page.tsx
+++ b/app/(back)/rallies/[id]/page.tsx
@@ -7,26 +7,32 @@ import { RallyPageProps } from './types';
 
 export default async function RallyPage({ params: { id } }: RallyPageProps) {
   const viewerId = (await getMember())?.id;
-  // TODO - get stampable from api
-  const stampable = true;
-  // TODO - get stampable from api
   const {
     title,
     status,
-    // stampable,
+    stampable,
     dueDate: deadline,
     createdAt,
     updatedAt,
+    completionDate,
     stampCount: count,
     starter: { id: starterId },
-    kit: { stamps },
+    kit: { stamps, rewardImage },
   } = await getRallyData(id);
   const { owned, total } = getRallyInfo({ stamps, updatedAt, starterId, viewerId, createdAt });
 
   return (
     <main className="px-4 py-6 w-full bg-grey-50 flex flex-col gap-6">
       <RallyInfo title={title} status={status} count={count} total={total} createdAt={createdAt} updatedAt={updatedAt} deadline={deadline} />
-      <RallyStamps owned={owned} stamps={stamps} count={count} total={total} stampable={stampable} />
+      <RallyStamps
+        owned={owned}
+        stamps={stamps}
+        count={count}
+        total={total}
+        stampable={stampable}
+        rewardImage={rewardImage}
+        completionDate={completionDate}
+      />
       <RallyFooter owned={owned} status={status} count={count} total={total} stampable={stampable} rallyId={id} />
     </main>
   );

--- a/prisma/migrations/20240711150341_map_column_name/migration.sql
+++ b/prisma/migrations/20240711150341_map_column_name/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `completionDate` on the `Rally` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Rally" DROP COLUMN "completionDate",
+ADD COLUMN     "completedDate" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,7 +124,7 @@ model Rally {
   stampCount      Int         @default(0)
   lastStampDate   DateTime?
   dueDate         DateTime?
-  completionDate  DateTime?
+  completionDate  DateTime?   @map("completedDate")
   extendedDueDate DateTime?
   isPublic        Boolean     @default(true)
   createdAt       DateTime    @default(now())

--- a/types/Rally.ts
+++ b/types/Rally.ts
@@ -24,7 +24,9 @@ export interface CompletedRally extends MyRally {
 export type RallyData = Prisma.RallyGetPayload<{
   where: { id: string };
   select: typeof rallySelect;
-}>;
+}> & {
+  stampable: boolean;
+};
 export interface FetchRallyData extends RallyData {
   stampable: boolean;
 }


### PR DESCRIPTION
## 작업 내용

관련 이슈: #193 

`completionDate`가 존재하고 마지막 스탬프면 원본 이미지(리워드 이미지)를 표시합니다.
매번 스탬프를 찍을 때마다 리프레쉬하고 있으므로, 마지막 스탬프를 찍고 리프레쉬 될 때는 `completionDate`가 반드시 존재하게 됩니다.

## 테스트 내용

- [x] 랠리 완주 시 보상 이미지가 원본 이미지로 표시됩니다.

### 리뷰어에게
#### 리뷰하기 전
_리뷰어가 집중해서 봐주었으면 하는 부분을 작성해주세요._
_리뷰어가 리뷰를 진행하기 전 필요한 작업이 있다면 작성해주세요.(ex. yarn install 등)_

#### 리뷰 후
_리뷰 후 팀원들이 진행해야하는 작업이 있다면 작성해주세요. (ex. 머지하기 전 DB 칼럼 생성 등)_

### 체크리스트

- [ ] 리뷰하는데 20분 이상 필요한가요? _20분 초과할 경우, 예상 리뷰 시간을 덧붙여주세요_
- [ ] 셀프 리뷰를 진행했습니다.
- [ ] 커밋 메세지를 컨벤션에 맞게 작성했습니다.
- [ ] 테스트 내용에 기재된 항목에 대해서 실제로 테스트를 진행하고 동작을 확인했습니다.
