### PR TITLE
#176 개별 랠리 페이지 랠리 연장 모달 레이아웃 완성

### DIFF
--- a/app/(back)/rallies/[id]/@modal/(.)delete/page.tsx
+++ b/app/(back)/rallies/[id]/@modal/(.)delete/page.tsx
@@ -9,8 +9,8 @@ export default async function DeleteRallyModal({ params: { id } }: RallyPageProp
   return (
     <Modal back={`/rallies/${id}`} labels={{ submit: '포기하기', cancel: '뒤로가기' }} onSubmit={deleteRally}>
       <SadCat className="size-18 m-auto" />
-      <ModalTitle title={title} />
-      <ModalDescription description={description} />
+      <ModalTitle>{title}</ModalTitle>
+      <ModalDescription>{description}</ModalDescription>
     </Modal>
   );
 }

--- a/app/(back)/rallies/[id]/actions.ts
+++ b/app/(back)/rallies/[id]/actions.ts
@@ -1,0 +1,6 @@
+'use server';
+
+export const extendRally = async (form: FormData) => {
+  const id = form.get('id');
+  console.log(`Rally ${id} extended`);
+};

--- a/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
+++ b/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
@@ -1,53 +1,23 @@
 import Modal, { ModalDescription, ModalTitle } from '@/components/ParallelModal';
 import { SadCat } from '@/lib/icons';
 import { extendRally } from '../../actions';
-import { pipe } from '@fxts/core';
-import { bind, remain } from '@/lib/do';
+import { getExtendModalInfo } from './lib';
 
-interface ExtendModalProps extends Flags {
+interface ExtendModalProps {
   id: string;
   kitId: string;
-}
-interface Flags {
   extendable: boolean;
   startable: boolean;
 }
 
 export default async function ExtendModal({ id, kitId, extendable, startable }: ExtendModalProps) {
-  const labels = getLabels({ extendable, startable });
+  const { description, labels, cancel } = getExtendModalInfo({ kitId, extendable, startable });
   return (
-    <Modal back="/rallies" cancel={startable ? `/kits/${kitId}` : '/rallies'} labels={labels} onSubmit={extendRally} className="px-2">
+    <Modal back="/rallies" cancel={cancel} labels={labels} onSubmit={extendRally} className="px-4">
       <SadCat className="size-18 m-auto" />
       <input type="hidden" name="id" value={id} />
       <ModalTitle>아이쿠 아쉬워요!</ModalTitle>
-      {extendable ? <ExtendableDescription /> : <NotExtendableDescription />}
+      <ModalDescription className="whitespace-pre">{description}</ModalDescription>
     </Modal>
-  );
-}
-
-const getLabels = (e: Flags) => pipe(e, bind('submit', getSubmit), bind('cancel', getCancel), remain(['submit', 'cancel'] as const));
-const getSubmit = ({ extendable, startable }: Flags) => (extendable ? '기간 연장하기' : startable ? '같은 랠리로 새로 시작하기' : undefined);
-const getCancel = ({ extendable, startable }: Flags) => (extendable && startable ? '새로 시작하기' : undefined);
-
-function ExtendableDescription() {
-  return (
-    <ModalDescription>
-      기간안에 스탬프 랠리를 마무리 하지 못했어요!
-      <br />
-      1회 한정 남은 기간을 연장하여
-      <br />
-      랠리를 이어갈 수 있어요!
-    </ModalDescription>
-  );
-}
-function NotExtendableDescription() {
-  return (
-    <ModalDescription>
-      기간안에 스탬프 랠리를 마무리 하지 못했어요!
-      <br />
-      아쉽지만 이미 연장한 랠리는 또다시 연장할 수 없어요.
-      <br />
-      다시 한 번 도전해보는 건 어떨까요?
-    </ModalDescription>
   );
 }

--- a/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
+++ b/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
@@ -4,9 +4,11 @@ import { extendRally } from '../../actions';
 import { pipe } from '@fxts/core';
 import { bind, remain } from '@/lib/do';
 
-interface ExtendModalProps {
+interface ExtendModalProps extends Flags {
   id: string;
   kitId: string;
+}
+interface Flags {
   extendable: boolean;
   startable: boolean;
 }
@@ -23,13 +25,9 @@ export default async function ExtendModal({ id, kitId, extendable, startable }: 
   );
 }
 
-const getLabels = (e: { extendable: boolean; startable: boolean }) =>
-  pipe(
-    e,
-    bind('submit', ({ extendable, startable }) => (extendable ? '기간 연장하기' : startable ? '같은 랠리로 새로 시작하기' : undefined)),
-    bind('cancel', ({ extendable, startable }) => (extendable && startable ? '새로 시작하기' : undefined)),
-    remain(['submit', 'cancel'] as const),
-  );
+const getLabels = (e: Flags) => pipe(e, bind('submit', getSubmit), bind('cancel', getCancel), remain(['submit', 'cancel'] as const));
+const getSubmit = ({ extendable, startable }: Flags) => (extendable ? '기간 연장하기' : startable ? '같은 랠리로 새로 시작하기' : undefined);
+const getCancel = ({ extendable, startable }: Flags) => (extendable && startable ? '새로 시작하기' : undefined);
 
 function ExtendableDescription() {
   return (

--- a/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
+++ b/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
@@ -1,0 +1,20 @@
+import Modal, { ModalDescription, ModalTitle } from '@/components/ParallelModal';
+import { SadCat } from '@/lib/icons';
+import { extendRally } from '../../actions';
+
+export default async function ExtendModal({ id, kitId }: { id: string; kitId: string }) {
+  return (
+    <Modal back={`/kit/${kitId}`} labels={{ submit: '기간 연장하기', cancel: '새로 시작하기' }} onSubmit={extendRally}>
+      <SadCat className="size-18 m-auto" />
+      <input type="hidden" name="id" value={id} />
+      <ModalTitle>아이쿠 아쉬워요!</ModalTitle>
+      <ModalDescription>
+        기간안에 스탬프 랠리를 마무리 하지 못했어요!
+        <br />
+        1회 한정 남은 기간을 연장하여
+        <br />
+        랠리를 이어갈 수 있어요!
+      </ModalDescription>
+    </Modal>
+  );
+}

--- a/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
+++ b/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
@@ -12,18 +12,13 @@ interface ExtendModalProps {
 }
 
 export default async function ExtendModal({ id, kitId, extendable, startable }: ExtendModalProps) {
+  const labels = getLabels({ extendable, startable });
   return (
-    <Modal back={`/kit/${kitId}`} labels={{ submit: '기간 연장하기', cancel: '새로 시작하기' }} onSubmit={extendRally}>
+    <Modal back="/rallies" cancel={startable ? `/kits/${kitId}` : '/rallies'} labels={labels} onSubmit={extendRally} className="px-2">
       <SadCat className="size-18 m-auto" />
       <input type="hidden" name="id" value={id} />
       <ModalTitle>아이쿠 아쉬워요!</ModalTitle>
-      <ModalDescription>
-        기간안에 스탬프 랠리를 마무리 하지 못했어요!
-        <br />
-        1회 한정 남은 기간을 연장하여
-        <br />
-        랠리를 이어갈 수 있어요!
-      </ModalDescription>
+      {extendable ? <ExtendableDescription /> : <NotExtendableDescription />}
     </Modal>
   );
 }

--- a/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
+++ b/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
@@ -1,6 +1,8 @@
 import Modal, { ModalDescription, ModalTitle } from '@/components/ParallelModal';
 import { SadCat } from '@/lib/icons';
 import { extendRally } from '../../actions';
+import { pipe } from '@fxts/core';
+import { bind, remain } from '@/lib/do';
 
 interface ExtendModalProps {
   id: string;
@@ -25,6 +27,14 @@ export default async function ExtendModal({ id, kitId, extendable, startable }: 
     </Modal>
   );
 }
+
+const getLabels = (e: { extendable: boolean; startable: boolean }) =>
+  pipe(
+    e,
+    bind('submit', ({ extendable, startable }) => (extendable ? '기간 연장하기' : startable ? '같은 랠리로 새로 시작하기' : undefined)),
+    bind('cancel', ({ extendable, startable }) => (extendable && startable ? '새로 시작하기' : undefined)),
+    remain(['submit', 'cancel'] as const),
+  );
 
 function ExtendableDescription() {
   return (

--- a/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
+++ b/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
@@ -18,3 +18,26 @@ export default async function ExtendModal({ id, kitId }: { id: string; kitId: st
     </Modal>
   );
 }
+
+function ExtendableDescription() {
+  return (
+    <ModalDescription>
+      기간안에 스탬프 랠리를 마무리 하지 못했어요!
+      <br />
+      1회 한정 남은 기간을 연장하여
+      <br />
+      랠리를 이어갈 수 있어요!
+    </ModalDescription>
+  );
+}
+function NotExtendableDescription() {
+  return (
+    <ModalDescription>
+      기간안에 스탬프 랠리를 마무리 하지 못했어요!
+      <br />
+      아쉽지만 이미 연장한 랠리는 또다시 연장할 수 없어요.
+      <br />
+      다시 한 번 도전해보는 건 어떨까요?
+    </ModalDescription>
+  );
+}

--- a/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
+++ b/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
@@ -2,7 +2,14 @@ import Modal, { ModalDescription, ModalTitle } from '@/components/ParallelModal'
 import { SadCat } from '@/lib/icons';
 import { extendRally } from '../../actions';
 
-export default async function ExtendModal({ id, kitId }: { id: string; kitId: string }) {
+interface ExtendModalProps {
+  id: string;
+  kitId: string;
+  extendable: boolean;
+  startable: boolean;
+}
+
+export default async function ExtendModal({ id, kitId, extendable, startable }: ExtendModalProps) {
   return (
     <Modal back={`/kit/${kitId}`} labels={{ submit: '기간 연장하기', cancel: '새로 시작하기' }} onSubmit={extendRally}>
       <SadCat className="size-18 m-auto" />

--- a/app/(back)/rallies/[id]/components/ExtendModal/lib.ts
+++ b/app/(back)/rallies/[id]/components/ExtendModal/lib.ts
@@ -1,0 +1,37 @@
+import { pipe } from '@fxts/core';
+import { bind, remain } from '@/lib/do';
+
+interface Flags {
+  extendable: boolean;
+  startable: boolean;
+}
+
+export const getExtendModalInfo = (e: Flags & { kitId: string }) =>
+  pipe(
+    e,
+    bind('cancel', getCancelLink),
+    bind('labels', getLabels),
+    bind('description', getDescription),
+    remain(['cancel', 'labels', 'description'] as const),
+  );
+const getCancelLink = (e: Flags & { kitId: string }) => (e.extendable && e.startable ? `/kits/${e.kitId}` : '/rallies');
+const getDescription = ({ extendable, startable }: Flags) =>
+  extendable ? descriptions.extendable : startable ? descriptions.notExtendable : descriptions.notStartable;
+const getLabels = (e: Flags) => pipe(e, bind('submit', getSubmit), bind('cancel', getCancel), remain(['submit', 'cancel'] as const));
+const getSubmit = ({ extendable, startable }: Flags) => (extendable ? submits.extendable : startable ? submits.notExtendable : submits.notStartable);
+const getCancel = ({ extendable, startable }: Flags) => (extendable && startable ? cancels.extendable : undefined);
+
+const submits = {
+  extendable: '기간 연장하기',
+  notExtendable: '같은 랠리로 새로 시작하기',
+  notStartable: '다른 랠리로 시작하기',
+} as const;
+const cancels = {
+  extendable: '새로 시작하기',
+} as const;
+const descriptions = {
+  extendable: '기간안에 스탬프 랠리를 마무리 하지 못했어요!\n1회 한정 남은 기간을 연장하여\n랠리를 이어갈 수 있어요!',
+  notExtendable:
+    '기간안에 스탬프 랠리를 마무리 하지 못했어요!\n아쉽지만 이미 연장한 랠리는 또다시 연장할 수 없어요.\n다시 한 번 도전해보는 건 어떨까요?',
+  notStartable: '키트가 삭제되어 랠리를 다시 시작할 수 없어요!\n다른 키트를 찾아볼까요?',
+} as const;

--- a/app/(back)/rallies/[id]/components/ExtendModal/lib.ts
+++ b/app/(back)/rallies/[id]/components/ExtendModal/lib.ts
@@ -23,8 +23,8 @@ const getCancel = ({ extendable, startable }: Flags) => (extendable && startable
 
 const submits = {
   extendable: '기간 연장하기',
-  notExtendable: '같은 랠리로 새로 시작하기',
-  notStartable: '다른 랠리로 시작하기',
+  notExtendable: '같은 키트로 새로 시작하기',
+  notStartable: '다른 키트로 시작하기',
 } as const;
 const cancels = {
   extendable: '새로 시작하기',

--- a/app/(back)/rallies/[id]/components/RallyInfo.tsx
+++ b/app/(back)/rallies/[id]/components/RallyInfo.tsx
@@ -3,10 +3,10 @@ import { RallyData } from '@/types/Rally';
 import { rallyInfoStyles as styles } from './styles';
 import { getRallyDates, GetRallyDatesProps } from '../lib';
 
-interface RallyInfoProps extends Pick<RallyData, 'title' | 'createdAt' | 'updatedAt' | 'status'>, GetRallyDatesProps {}
+interface RallyInfoProps extends Pick<RallyData, 'title' | 'createdAt' | 'updatedAt' | 'status' | 'completionDate'>, GetRallyDatesProps {}
 
-export default function RallyInfo({ title, createdAt, updatedAt, deadline, status, count, total }: RallyInfoProps) {
-  const { dDay, since, completedAt, percentage } = getRallyDates({ createdAt, updatedAt, deadline, status, count, total });
+export default function RallyInfo({ title, createdAt, updatedAt, deadline, status, count, total, completionDate }: RallyInfoProps) {
+  const { dDay, since, completedAt, percentage } = getRallyDates({ createdAt, updatedAt, deadline, status, count, total, completionDate });
 
   return (
     <section className={styles.container}>

--- a/app/(back)/rallies/[id]/components/RallyStamps.tsx
+++ b/app/(back)/rallies/[id]/components/RallyStamps.tsx
@@ -1,4 +1,4 @@
-import { RallyStamp, StampKind } from '@/components/RallyStamp';
+import { RallyStamp } from '@/components/RallyStamp';
 import { RallyPreviewStamp } from '@/types/Stamp';
 import { rallyStampsStyles } from './styles';
 import { RallyStampsInfo } from './types';
@@ -6,8 +6,6 @@ import { addStampPropsByIndex } from './lib';
 
 interface RallyStampsProps extends RallyStampsInfo {
   stamps: RallyPreviewStamp[];
-  completionDate: Date | null;
-  rewardImage: string;
 }
 
 export default function RallyStamps({ stamps, total, count, owned, stampable, rewardImage, completionDate }: RallyStampsProps) {
@@ -15,10 +13,11 @@ export default function RallyStamps({ stamps, total, count, owned, stampable, re
     <article className={rallyStampsStyles.container}>
       <h2 className={rallyStampsStyles.title}>스탬프 랠리</h2>
       <section className={rallyStampsStyles.stamps}>
-        {stamps.map(addStampPropsByIndex({ owned, count, total, stampable })).map(({ id, objectKey, status, kind, owned }, index) => {
-          if (kind === StampKind.reward && completionDate) objectKey = rewardImage;
-          return <RallyStamp key={id} id={id} objectKey={objectKey} status={status} kind={kind} owned={owned} />;
-        })}
+        {stamps
+          .map(addStampPropsByIndex({ owned, count, total, stampable, rewardImage, completionDate }))
+          .map(({ id, objectKey, status, kind, owned }) => (
+            <RallyStamp key={id} id={id} objectKey={objectKey} status={status} kind={kind} owned={owned} />
+          ))}
       </section>
     </article>
   );

--- a/app/(back)/rallies/[id]/components/lib.ts
+++ b/app/(back)/rallies/[id]/components/lib.ts
@@ -1,7 +1,7 @@
 import { always, every, identity, juxt, pipe, prop, tap } from '@fxts/core';
 import { filter, lift, match, of } from '@/lib/either';
 import { Do, bind, assign } from '@/lib/do';
-import { cn, eq, everyEq, notNull, tapLog } from '@/lib/utils';
+import { cn, eq, everyEq, notNull } from '@/lib/utils';
 import { StampStatus, StampKind } from '@/components/RallyStamp';
 import { RallyStatus } from '@/types/Rally';
 import { RallyPreviewStamp } from '@/types/Stamp';
@@ -14,7 +14,7 @@ export const addStampPropsByIndex = (info: RallyStampsInfo) => (stamp: RallyPrev
   pipe(Do, assign(stamp), assign(info), bind('index', always(index)), bindStampInfo);
 const bindStampInfo = (e: StampData) => pipe(e, bind('status', getStampStatus), bind('kind', getStampKind), bind('objectKey', replaceWithReward));
 
-const getStampStatus = (e: StampData) => pipe(e, of<StampStatus, typeof e>, filterChecked, filterUncheckable, tapLog('getStampStatus'), mapCheckable);
+const getStampStatus = (e: StampData) => pipe(e, of<StampStatus, typeof e>, filterChecked, filterUncheckable, mapCheckable);
 const filterChecked = filter(({ index, count }: StampData) => index >= count, always(StampStatus.checked));
 const isCheckable = (e: StampData) => pipe(e, juxt([prop('stampable'), isIndexCount]), every(Boolean));
 const filterUncheckable = filter(isCheckable, always(StampStatus.uncheckable));

--- a/app/(back)/rallies/[id]/components/types.ts
+++ b/app/(back)/rallies/[id]/components/types.ts
@@ -5,6 +5,8 @@ export interface RallyStampsInfo {
   count: number;
   owned: boolean;
   stampable: boolean;
+  rewardImage: string;
+  completionDate: Date | null;
 }
 export interface RewardableConditionsProps {
   count: number;

--- a/app/(back)/rallies/[id]/lib.ts
+++ b/app/(back)/rallies/[id]/lib.ts
@@ -60,11 +60,14 @@ export const getRallyInfo = (data: GetRallyInfoProps) =>
     derive('total')(({ stamps }) => stamps.length), // 전체 스탬프 개수
     derive('failed')(isFailed), // 실패 여부
     derive('extendable')(isNeverExtendedBefore), // 연장 가능 여부
+    derive('startable')(isKitExist), // 시작 가능 여부
+    remain(['owned', 'total', 'failed', 'extendable', 'startable'] as const), // 필요한 값만 남기기
   );
 const isFailed = <T extends GetRallyInfoProps>(e: T) => pipe(e, juxt([isInactive, notCompleted]), every(Boolean));
 const isInactive = (e: GetRallyInfoProps) => pipe(e, prop('status'), eq(RallyStatus.inactive));
 const notCompleted = (e: GetRallyInfoProps) => pipe(e, prop('completionDate'), isNull);
 const isNeverExtendedBefore = <T extends GetRallyInfoProps>(e: T) => pipe(e, prop('extendedDueDate'), isNull);
+const isKitExist = <T extends GetRallyInfoProps>(e: T) => pipe(e, prop('kitDeletedAt'), isNull);
 
 export interface GetRallyDatesProps extends Pick<FetchRallyData, 'createdAt' | 'updatedAt' | 'status' | 'completionDate'> {
   count: number;

--- a/app/(back)/rallies/[id]/lib.ts
+++ b/app/(back)/rallies/[id]/lib.ts
@@ -1,4 +1,5 @@
 import { notFound } from 'next/navigation';
+import type { GET } from '@/app/api/rallies/[id]/route';
 import { every, evolve, isNull, join, juxt, pipe, prop, tap } from '@fxts/core';
 import { constNull } from '@/lib/always';
 import { convertMsToDate, displayDateYyMmDd, now, diffDates, parseDate, parseNullableDate } from '@/lib/date';
@@ -8,6 +9,9 @@ import { resolveJson, validResponse } from '@/lib/response';
 import { eq, derive, remain, everyTrue, notNull, tapLog } from '@/lib/utils';
 import { FetchedRallyData, FetchRallyData, RallyStatus } from '@/types/Rally';
 
+/**
+ * {@link GET API}
+ */
 export const getRallyData = async (id: string) =>
   pipe(
     id,
@@ -38,11 +42,15 @@ const parseRallyDates: (fetched: FetchedRallyData) => FetchRallyData = evolve({
   lastStampDate: parseNullableDate,
   completionDate: parseNullableDate,
   extendedDueDate: parseNullableDate,
+  kit: evolve({
+    deletedAt: parseNullableDate,
+  }),
 });
 
 interface GetRallyInfoProps extends Pick<FetchRallyData, 'status' | 'completionDate'> {
   stamps: FetchRallyData['kit']['stamps'];
   starterId: FetchRallyData['starter']['id'];
+  kitDeletedAt: FetchRallyData['kit']['deletedAt'];
   viewerId?: string;
 }
 export const getRallyInfo = (data: GetRallyInfoProps) =>

--- a/app/(back)/rallies/[id]/lib.ts
+++ b/app/(back)/rallies/[id]/lib.ts
@@ -47,7 +47,7 @@ const parseRallyDates: (fetched: FetchedRallyData) => FetchRallyData = evolve({
   }),
 });
 
-interface GetRallyInfoProps extends Pick<FetchRallyData, 'status' | 'completionDate'> {
+interface GetRallyInfoProps extends Pick<FetchRallyData, 'status' | 'completionDate' | 'extendedDueDate'> {
   stamps: FetchRallyData['kit']['stamps'];
   starterId: FetchRallyData['starter']['id'];
   kitDeletedAt: FetchRallyData['kit']['deletedAt'];
@@ -59,11 +59,12 @@ export const getRallyInfo = (data: GetRallyInfoProps) =>
     derive('owned')(({ starterId, viewerId }) => starterId === viewerId), // starterId와 viewerId가 같은지로 소유 여부 확인
     derive('total')(({ stamps }) => stamps.length), // 전체 스탬프 개수
     derive('failed')(isFailed), // 실패 여부
-    remain(['owned', 'total', 'failed'] as const), // 필요한 값만 남기기
+    derive('extendable')(isNeverExtendedBefore), // 연장 가능 여부
   );
 const isFailed = <T extends GetRallyInfoProps>(e: T) => pipe(e, juxt([isInactive, notCompleted]), every(Boolean));
 const isInactive = (e: GetRallyInfoProps) => pipe(e, prop('status'), eq(RallyStatus.inactive));
 const notCompleted = (e: GetRallyInfoProps) => pipe(e, prop('completionDate'), isNull);
+const isNeverExtendedBefore = <T extends GetRallyInfoProps>(e: T) => pipe(e, prop('extendedDueDate'), isNull);
 
 export interface GetRallyDatesProps extends Pick<FetchRallyData, 'createdAt' | 'updatedAt' | 'status' | 'completionDate'> {
   count: number;

--- a/app/(back)/rallies/[id]/page.tsx
+++ b/app/(back)/rallies/[id]/page.tsx
@@ -16,11 +16,20 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
     createdAt,
     updatedAt,
     completionDate,
+    extendedDueDate,
     stampCount: count,
     starter: { id: starterId },
-    kit: { id: kitId, stamps, rewardImage },
+    kit: { id: kitId, stamps, rewardImage, deletedAt: kitDeletedAt },
   } = await getRallyData(id);
-  const { owned, total, failed } = getRallyInfo({ status, completionDate, stamps, starterId, viewerId });
+  const { owned, total, failed, extendable, startable } = getRallyInfo({
+    status,
+    completionDate,
+    stamps,
+    starterId,
+    viewerId,
+    kitDeletedAt,
+    extendedDueDate,
+  });
 
   return (
     <main className="px-4 py-6 w-full bg-grey-50 flex flex-col gap-6">
@@ -44,7 +53,7 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
         completionDate={completionDate}
       />
       <RallyFooter owned={owned} status={status} count={count} total={total} stampable={stampable} rallyId={id} />
-      {owned && failed && <ExtendModal id={id} kitId={kitId} />}
+      {owned && failed && <ExtendModal id={id} kitId={kitId} extendable={extendable} startable={startable} />}
     </main>
   );
 }

--- a/app/(back)/rallies/[id]/page.tsx
+++ b/app/(back)/rallies/[id]/page.tsx
@@ -8,13 +8,10 @@ import ExtendModal from './components/ExtendModal';
 
 export default async function RallyPage({ params: { id } }: RallyPageProps) {
   const viewerId = (await getMember())?.id;
-  // TODO - get stampable from api
-  const stampable = true;
-  // TODO - get stampable from api
   const {
     title,
     status,
-    // stampable,
+    stampable,
     dueDate: deadline,
     createdAt,
     updatedAt,

--- a/app/(back)/rallies/[id]/page.tsx
+++ b/app/(back)/rallies/[id]/page.tsx
@@ -17,11 +17,12 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
     dueDate: deadline,
     createdAt,
     updatedAt,
+    completionDate,
     stampCount: count,
     starter: { id: starterId },
     kit: { stamps },
   } = await getRallyData(id);
-  const { owned, total } = getRallyInfo({ stamps, updatedAt, starterId, viewerId, createdAt });
+  const { owned, total, failed } = getRallyInfo({ status, completionDate, stamps, starterId, viewerId });
 
   return (
     <main className="px-4 py-6 w-full bg-grey-50 flex flex-col gap-6">

--- a/app/(back)/rallies/[id]/page.tsx
+++ b/app/(back)/rallies/[id]/page.tsx
@@ -24,7 +24,16 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
 
   return (
     <main className="px-4 py-6 w-full bg-grey-50 flex flex-col gap-6">
-      <RallyInfo title={title} status={status} count={count} total={total} createdAt={createdAt} updatedAt={updatedAt} deadline={deadline} />
+      <RallyInfo
+        title={title}
+        status={status}
+        count={count}
+        total={total}
+        createdAt={createdAt}
+        updatedAt={updatedAt}
+        deadline={deadline}
+        completionDate={completionDate}
+      />
       <RallyStamps owned={owned} stamps={stamps} count={count} total={total} stampable={stampable} />
       <RallyFooter owned={owned} status={status} count={count} total={total} stampable={stampable} rallyId={id} />
       {owned && failed && <ExtendModal id={id} kitId={kitId} />}

--- a/app/(back)/rallies/[id]/page.tsx
+++ b/app/(back)/rallies/[id]/page.tsx
@@ -4,6 +4,7 @@ import RallyInfo from './components/RallyInfo';
 import RallyStamps from './components/RallyStamps';
 import RallyFooter from './components/RallyFooter';
 import { RallyPageProps } from './types';
+import ExtendModal from './components/ExtendModal';
 
 export default async function RallyPage({ params: { id } }: RallyPageProps) {
   const viewerId = (await getMember())?.id;
@@ -20,7 +21,7 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
     completionDate,
     stampCount: count,
     starter: { id: starterId },
-    kit: { stamps },
+    kit: { id: kitId, stamps },
   } = await getRallyData(id);
   const { owned, total, failed } = getRallyInfo({ status, completionDate, stamps, starterId, viewerId });
 
@@ -29,6 +30,7 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
       <RallyInfo title={title} status={status} count={count} total={total} createdAt={createdAt} updatedAt={updatedAt} deadline={deadline} />
       <RallyStamps owned={owned} stamps={stamps} count={count} total={total} stampable={stampable} />
       <RallyFooter owned={owned} status={status} count={count} total={total} stampable={stampable} rallyId={id} />
+      {owned && failed && <ExtendModal id={id} kitId={kitId} />}
     </main>
   );
 }

--- a/app/api/lib/prisma/selects.ts
+++ b/app/api/lib/prisma/selects.ts
@@ -15,6 +15,7 @@ export const kitSelect = {
   },
   createdAt: true,
   updatedAt: true,
+  deletedAt: true,
 } satisfies Prisma.KitSelect;
 
 export const kitCardSelect = {

--- a/components/ParallelModal/index.tsx
+++ b/components/ParallelModal/index.tsx
@@ -24,12 +24,12 @@ export default function Modal({ back = defaults.back, labels = defaults.labels, 
 function Backdrop({ back }: { back: string }) {
   return <Link href={back} className={styles.backdrop} />;
 }
-export function ModalTitle({ title }: { title: string }) {
-  return <h1 className={styles.title}>{title}</h1>;
+export function ModalTitle({ children }: { children?: React.ReactNode }) {
+  return <h1 className={styles.title}>{children}</h1>;
 }
 
-export function ModalDescription({ description }: { description: string }) {
-  return <p className={styles.description}>{description}</p>;
+export function ModalDescription({ children }: { children?: React.ReactNode }) {
+  return <p className={styles.description}>{children}</p>;
 }
 
 function Buttons({ back, submit, cancel }: { back: string; submit?: string; cancel?: string }) {

--- a/components/ParallelModal/index.tsx
+++ b/components/ParallelModal/index.tsx
@@ -1,19 +1,27 @@
 import Link from 'next/link';
 import styles from './styles';
 import { defaults } from './lib';
+import { cn } from '@/lib/utils';
 
 interface ParallelModalProps {
   back: string;
   labels: { submit?: string; cancel?: string };
   onSubmit: (form: FormData) => Promise<void>;
+  className?: string;
   children?: React.ReactNode;
 }
 
-export default function Modal({ back = defaults.back, labels = defaults.labels, onSubmit = defaults.onSubmit, children }: ParallelModalProps) {
+export default function Modal({
+  back = defaults.back,
+  labels = defaults.labels,
+  onSubmit = defaults.onSubmit,
+  className,
+  children,
+}: ParallelModalProps) {
   return (
     <>
       <Backdrop back={back} />
-      <form className={styles.container} action={onSubmit}>
+      <form className={cn(styles.container, className)} action={onSubmit}>
         {children}
         <Buttons back={back} {...labels} />
       </form>
@@ -28,8 +36,8 @@ export function ModalTitle({ children }: { children?: React.ReactNode }) {
   return <h1 className={styles.title}>{children}</h1>;
 }
 
-export function ModalDescription({ children }: { children?: React.ReactNode }) {
-  return <p className={styles.description}>{children}</p>;
+export function ModalDescription({ children, className }: { children?: React.ReactNode; className?: string }) {
+  return <p className={cn(styles.description, className)}>{children}</p>;
 }
 
 function Buttons({ back, submit, cancel }: { back: string; submit?: string; cancel?: string }) {

--- a/components/ParallelModal/index.tsx
+++ b/components/ParallelModal/index.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils';
 
 interface ParallelModalProps {
   back: string;
+  cancel?: string;
   labels: { submit?: string; cancel?: string };
   onSubmit: (form: FormData) => Promise<void>;
   className?: string;
@@ -13,6 +14,7 @@ interface ParallelModalProps {
 
 export default function Modal({
   back = defaults.back,
+  cancel,
   labels = defaults.labels,
   onSubmit = defaults.onSubmit,
   className,
@@ -23,7 +25,7 @@ export default function Modal({
       <Backdrop back={back} />
       <form className={cn(styles.container, className)} action={onSubmit}>
         {children}
-        <Buttons back={back} {...labels} />
+        <Buttons back={cancel ?? back} {...labels} />
       </form>
     </>
   );

--- a/components/ParallelModal/index.tsx
+++ b/components/ParallelModal/index.tsx
@@ -4,7 +4,7 @@ import { defaults } from './lib';
 
 interface ParallelModalProps {
   back: string;
-  labels: { submit: string; cancel: string };
+  labels: { submit?: string; cancel?: string };
   onSubmit: (form: FormData) => Promise<void>;
   children?: React.ReactNode;
 }
@@ -32,15 +32,19 @@ export function ModalDescription({ description }: { description: string }) {
   return <p className={styles.description}>{description}</p>;
 }
 
-function Buttons({ back, submit, cancel }: { back: string; submit: string; cancel: string }) {
+function Buttons({ back, submit, cancel }: { back: string; submit?: string; cancel?: string }) {
   return (
     <section className={styles.buttons}>
-      <Link href={back} className={styles.cancel}>
-        {cancel}
-      </Link>
-      <button type="submit" className={styles.submit}>
-        {submit}
-      </button>
+      {cancel && (
+        <Link href={back} className={styles.cancel}>
+          {cancel}
+        </Link>
+      )}
+      {submit && (
+        <button type="submit" className={styles.submit}>
+          {submit}
+        </button>
+      )}
     </section>
   );
 }

--- a/components/ParallelModal/styles.ts
+++ b/components/ParallelModal/styles.ts
@@ -2,10 +2,10 @@ const ParallelModalStyles = {
   container:
     'fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[328px] shadow-lg bg-background text-center p-6 flex flex-col gap-6 rounded-xl z-50',
   backdrop: 'fixed top-0 bottom-0 left-0 right-0 bg-grey-400/20 backdrop-blur-sm z-50 ease-in',
-  description: 'text-grey-400 text-sm',
+  description: 'text-foreground/60 text-sm',
   title: 'text-xl font-bold text-primary -mb-4',
-  buttons: `flex gap-2 justify-stretch [&>*]:py-4 [&>*]:rounded-xl [&>*]:flex-1`,
-  cancel: 'border text-grey-400',
+  buttons: `flex gap-2 justify-stretch font-bold [&>*]:py-4 [&>*]:rounded-xl [&>*]:flex-1`,
+  cancel: 'border text-foreground/60',
   submit: 'bg-primary text-white',
 };
 export default ParallelModalStyles;

--- a/lib/do.ts
+++ b/lib/do.ts
@@ -4,8 +4,8 @@ export const Do: {} = {};
  */
 export const bind =
   <N extends PropertyKey, A, B>(name: N, f: (a: A) => B) =>
-  (a: A): { readonly [K in N | keyof A]: K extends N ? B : K extends keyof A ? A[K] : never } =>
-    ({ ...a, [name]: f(a) } as { readonly [K in N | keyof A]: K extends N ? B : K extends keyof A ? A[K] : never });
+  <C extends A>(a: C): { readonly [K in N | keyof C]: K extends N ? B : K extends keyof C ? C[K] : never } =>
+    ({ ...a, [name]: f(a) } as { readonly [K in N | keyof C]: K extends N ? B : K extends keyof C ? C[K] : never });
 /**
  * a -> b -> a & b
  */

--- a/lib/do.ts
+++ b/lib/do.ts
@@ -1,0 +1,24 @@
+export const Do: {} = {};
+/**
+ * n, f -> a -> a & { n: f(a) }
+ */
+export const bind =
+  <N extends PropertyKey, A, B>(name: N, f: (a: A) => B) =>
+  (a: A): { readonly [K in N | keyof A]: K extends N ? B : K extends keyof A ? A[K] : never } =>
+    ({ ...a, [name]: f(a) } as { readonly [K in N | keyof A]: K extends N ? B : K extends keyof A ? A[K] : never });
+/**
+ * a -> b -> a & b
+ */
+export const assign =
+  <T>(a: T) =>
+  <S>(b: S): { readonly [K in keyof S | keyof T]: K extends keyof T ? T[K] : K extends keyof S ? S[K] : never } =>
+    Object.assign({}, a, b) as { readonly [K in keyof S | keyof T]: K extends keyof T ? T[K] : K extends keyof S ? S[K] : never };
+/**
+ * k[] -> o -> { k: o[k] }
+ */
+export const remain =
+  <K extends string, P extends K>(props: P[]) =>
+  <T extends { [P in K]: T[P] }>(obj: T) =>
+    Object.fromEntries((Object.entries(obj) as [P, T[P]][]).filter(([key]) => props.includes(key))) as {
+      [Q in P]: T[Q];
+    };

--- a/lib/either.ts
+++ b/lib/either.ts
@@ -39,7 +39,7 @@ export const bimap =
  * f:(e -> never) -> Either e a -> a
  */
 export const purify =
-  <L, R>(onLeft: (left?: L) => never) =>
+  <L, R>(onLeft: (left: L) => never) =>
   (e: Either<L, R>): R =>
     isLeft(e) ? onLeft(e.left) : e.right;
 /**

--- a/lib/either.ts
+++ b/lib/either.ts
@@ -2,6 +2,7 @@ export type Left<L> = { _tag: 'Left'; left: L };
 export type Right<R> = { _tag: 'Right'; right: R };
 export type Either<L, R> = Left<L> | Right<R>;
 
+export const of = <L, R>(e: R): Either<L, R> => right(e);
 export const left = <L>(left: L): Left<L> => ({ _tag: 'Left', left });
 export const isLeft = <L, R>(e: Either<L, R>): e is Left<L> => e._tag === 'Left';
 export const right = <R>(right: R): Right<R> => ({ _tag: 'Right', right });


### PR DESCRIPTION
## 작업 내용

관련 이슈: #176
개별 랠리 페이지 랠리 연장 모달을 완성했습니다.

## 테스트 내용

- [ ] 연장 가능한 랠리
  <img width="339" alt="image" src="https://github.com/user-attachments/assets/c57b6ac7-e4a8-4e04-b263-a36d4b569330">
- [ ] 연장 불가능한 랠리
  <img width="349" alt="image" src="https://github.com/user-attachments/assets/dc7739f9-964a-4602-a7dd-eaf5ed750c47">

### 리뷰어에게
`app/(back)/rallies/[id]/components/ExtendModal/index.tsx` 와 관련 파일 위주로 리뷰 부탁드립니다.

### 체크리스트

- [ ] 리뷰하는데 20분 이상 필요한가요? _20분 초과할 경우, 예상 리뷰 시간을 덧붙여주세요_
- [x] 셀프 리뷰를 진행했습니다.
- [x] 커밋 메세지를 컨벤션에 맞게 작성했습니다.
- [x] 테스트 내용에 기재된 항목에 대해서 실제로 테스트를 진행하고 동작을 확인했습니다.
