### PR TITLE
#173 종료한 랠리 페이지 실패/완주 표시 완성

### DIFF
--- a/app/(info)/my/completes/components/CompletedLabel/index.tsx
+++ b/app/(info)/my/completes/components/CompletedLabel/index.tsx
@@ -1,0 +1,12 @@
+import { cn } from '@/lib/utils';
+
+export default function CompletedLabel({ completed }: { completed: boolean }) {
+  const label = completed ? '완주' : '실패';
+  return <span className={styles(completed)}>{label}</span>;
+}
+
+const styles = (completed: boolean) =>
+  cn('absolute top-2 left-2 px-3 py-2 rounded-lg font-bold border border-current text-sm', {
+    'text-primary bg-primary-100': completed,
+    'text-grey-100 bg-gray-50': !completed,
+  });

--- a/app/(info)/my/completes/components/InactiveRallies/index.tsx
+++ b/app/(info)/my/completes/components/InactiveRallies/index.tsx
@@ -1,0 +1,19 @@
+import { MyRally } from '@/types/Rally';
+import { getInfo } from './lib';
+import InactiveRallyCard from '../InactiveRallyCard';
+import ShowCompletedOnly from '../ShowCompletedOnly';
+
+export default function InactiveRallies({ rallies }: { rallies: MyRally[] }) {
+  return (
+    <section className={styles.container}>
+      <ShowCompletedOnly />
+      {rallies.map(getInfo).map(({ id, title, completed, updatedAt, kit: { thumbnailImage } }) => (
+        <InactiveRallyCard key={id} id={id} title={title} completed={completed} updatedAt={updatedAt} thumbnailImage={thumbnailImage} />
+      ))}
+    </section>
+  );
+}
+
+const styles = {
+  container: 'px-4 py-3 grid grid-cols-2 gap-x-2 gap-y-4 group',
+};

--- a/app/(info)/my/completes/components/InactiveRallies/lib.ts
+++ b/app/(info)/my/completes/components/InactiveRallies/lib.ts
@@ -2,7 +2,7 @@ import { bind } from '@/lib/do';
 import { MyRally } from '@/types/Rally';
 import { pipe } from '@fxts/core';
 
-export const getInfo = (rally: MyRally) => pipe(rally, bind('completed', isCompleted), bind('label', getLabel));
+export const getInfo = (rally: MyRally) => pipe(rally, bind('completed', isCompleted));
 
 const isCompleted = ({
   stampCount,
@@ -10,4 +10,3 @@ const isCompleted = ({
     stamps: { length },
   },
 }: MyRally) => stampCount === length;
-const getLabel = ({ completed }: { completed: boolean } & MyRally) => (completed ? '완료' : '실패');

--- a/app/(info)/my/completes/components/InactiveRallies/lib.ts
+++ b/app/(info)/my/completes/components/InactiveRallies/lib.ts
@@ -1,0 +1,13 @@
+import { bind } from '@/lib/do';
+import { MyRally } from '@/types/Rally';
+import { pipe } from '@fxts/core';
+
+export const getInfo = (rally: MyRally) => pipe(rally, bind('completed', isCompleted), bind('label', getLabel));
+
+const isCompleted = ({
+  stampCount,
+  kit: {
+    stamps: { length },
+  },
+}: MyRally) => stampCount === length;
+const getLabel = ({ completed }: { completed: boolean } & MyRally) => (completed ? '완료' : '실패');

--- a/app/(info)/my/completes/components/InactiveRallyCard/index.tsx
+++ b/app/(info)/my/completes/components/InactiveRallyCard/index.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import RallyCard from '@/components/RallyCard';
+import { cn } from '@/lib/utils';
+import { MyRally } from '@/types/Rally';
+import CompletedLabel from '../CompletedLabel';
+
+interface InactiveRallyCardProps extends Pick<MyRally, 'id' | 'title' | 'updatedAt'> {
+  completed: boolean;
+  thumbnailImage: MyRally['kit']['thumbnailImage'];
+}
+
+export default function InactiveRallyCard({ id, title, completed, updatedAt, thumbnailImage }: InactiveRallyCardProps) {
+  return (
+    <Link key={id} href={`/rallies/${id}`} className={styles.link(completed)}>
+      <RallyCard thumbnailImage={thumbnailImage} title={title} updatedAt={updatedAt} />
+      <CompletedLabel completed={completed} />
+    </Link>
+  );
+}
+
+const styles = {
+  link: (completed: boolean) => cn('relative', { 'group-has-[:checked]:hidden': !completed }),
+};

--- a/app/(info)/my/completes/components/ShowCompletedOnly/index.tsx
+++ b/app/(info)/my/completes/components/ShowCompletedOnly/index.tsx
@@ -3,7 +3,7 @@ import { Check } from '@/lib/icons';
 export default function ShowCompletedOnly() {
   return (
     <label className={styles.label}>
-      <input type="checkbox" className={styles.input} />
+      <input type="checkbox" className={styles.input} defaultChecked={true} />
       <Check className={styles.checkbox} />
       완주한 랠리만 보기
     </label>

--- a/app/(info)/my/completes/components/ShowCompletedOnly/index.tsx
+++ b/app/(info)/my/completes/components/ShowCompletedOnly/index.tsx
@@ -1,0 +1,17 @@
+import { Check } from '@/lib/icons';
+
+export default function ShowCompletedOnly() {
+  return (
+    <label className={styles.label}>
+      <input type="checkbox" className={styles.input} />
+      <Check className={styles.checkbox} />
+      완주한 랠리만 보기
+    </label>
+  );
+}
+
+const styles = {
+  label: 'col-span-full -mb-1 text-sm text-grey-300 cursor-pointer',
+  input: 'hidden peer',
+  checkbox: 'inline-block size-6 rounded p-0.5 mr-2 stroke-2 stroke-background fill-none bg-grey-100 peer-checked:bg-primary',
+};

--- a/app/(info)/my/completes/lib.ts
+++ b/app/(info)/my/completes/lib.ts
@@ -1,0 +1,13 @@
+import { MyRally, RallyStatus } from '@/types/Rally';
+import { filter, pipe, toArray } from '@fxts/core';
+import { fetchMyRallies } from '../lib';
+
+export const fetchMyInactiveRallies = async (userId: string) =>
+  pipe(
+    userId,
+    fetchMyRallies, // 사용자 랠리 목록 요청
+    filter(filterInactive), // 완료된 랠리 필터링
+    toArray, // 배열로 변환
+  );
+
+const filterInactive = ({ status }: MyRally) => status === RallyStatus.inactive;

--- a/app/(info)/my/completes/page.tsx
+++ b/app/(info)/my/completes/page.tsx
@@ -1,8 +1,7 @@
 import { Metadata } from 'next';
-import Link from 'next/link';
 import { ensureMember } from '@/auth';
-import RallyCard from '@/components/RallyCard';
 import EmptyContent from '../components/EmptyContent';
+import InactiveRallies from './components/InactiveRallies';
 import { fetchMyInactiveRallies } from './lib';
 
 export const metadata: Metadata = {
@@ -13,16 +12,5 @@ export default async function CompletesPage() {
   const { id: userId } = await ensureMember();
   const rallies = await fetchMyInactiveRallies(userId);
   if (rallies.length === 0) return <EmptyContent message="완료한 랠리가 없어요!" />;
-
-  return (
-    <article className="px-4 py-6 grid grid-cols-2 gap-x-2 gap-y-4">
-      {rallies
-        .filter(({ status }) => status === RallyStatus.inactive)
-        .map(({ id, updatedAt, title, kit: { thumbnailImage } }) => (
-          <Link key={id} href={`/rallies/${id}`}>
-            <RallyCard thumbnailImage={thumbnailImage} title={title} updatedAt={updatedAt} />
-          </Link>
-        ))}
-    </article>
-  );
+  return <InactiveRallies rallies={rallies} />;
 }

--- a/app/(info)/my/completes/page.tsx
+++ b/app/(info)/my/completes/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { ensureMember } from '@/auth';
 import RallyCard from '@/components/RallyCard';
 import EmptyContent from '../components/EmptyContent';
-import { RallyStatus, MyRally } from '@/types/Rally';
+import { fetchMyInactiveRallies } from './lib';
 
 export const metadata: Metadata = {
   title: '완료한 랠리',
@@ -11,8 +11,7 @@ export const metadata: Metadata = {
 
 export default async function CompletesPage() {
   const { id: userId } = await ensureMember();
-  const api = `${process.env.API_URL}/api/my/rallies?userId=${userId}`;
-  const { data: rallies }: { data: MyRally[] } = await fetch(api).then((res) => res.json());
+  const rallies = await fetchMyInactiveRallies(userId);
   if (rallies.length === 0) return <EmptyContent message="완료한 랠리가 없어요!" />;
 
   return (

--- a/app/(info)/my/components/MenuTabs/MenuTab.tsx
+++ b/app/(info)/my/components/MenuTabs/MenuTab.tsx
@@ -17,7 +17,7 @@ const getStyles = (isActive: boolean) =>
     [styles.inactive]: !isActive,
   });
 const styles = {
-  default: 'pb-2 flex-1 text-center transition duration-200',
+  default: 'pb-2 flex-1 text-center transition duration-200 border-b border-gray-200',
   active: 'font-bold text-primary border-b-2 border-primary z-10',
   inactive: 'text-grey-200',
 };

--- a/app/(info)/my/components/MenuTabs/index.tsx
+++ b/app/(info)/my/components/MenuTabs/index.tsx
@@ -16,4 +16,4 @@ export default function MenuTabs() {
   );
 }
 
-const styles = { container: 'flex w-full justify-stretch border-b border-gray-200 pt-2 sticky top-0' };
+const styles = { container: 'flex w-full justify-stretch pt-2 sticky top-0' };

--- a/app/(info)/my/joins/lib.ts
+++ b/app/(info)/my/joins/lib.ts
@@ -1,0 +1,13 @@
+import { MyRally, RallyStatus } from '@/types/Rally';
+import { filter, pipe, toArray } from '@fxts/core';
+import { fetchMyRallies } from '../lib';
+
+export const fetchMyActiveRallies = async (userId: string) =>
+  pipe(
+    userId,
+    fetchMyRallies, // 사용자 랠리 목록 요청
+    filter(filterActive), // 완료된 랠리 필터링
+    toArray, // 배열로 변환
+  );
+
+const filterActive = ({ status }: MyRally) => status === RallyStatus.active;

--- a/app/(info)/my/joins/page.tsx
+++ b/app/(info)/my/joins/page.tsx
@@ -3,7 +3,8 @@ import Link from 'next/link';
 import { ensureMember } from '@/auth';
 import RallyCard from '@/components/RallyCard';
 import EmptyContent from '../components/EmptyContent';
-import { MyRally, RallyStatus } from '@/types/Rally';
+import { RallyStatus } from '@/types/Rally';
+import { fetchMyActiveRallies } from './lib';
 
 export const metadata: Metadata = {
   title: '진행중인 랠리',
@@ -11,8 +12,7 @@ export const metadata: Metadata = {
 
 export default async function JoinsPage() {
   const { id: userId } = await ensureMember();
-  const api = `${process.env.API_URL}/api/my/rallies?userId=${userId}`;
-  const { data: rallies }: { data: MyRally[] } = await fetch(api).then((res) => res.json());
+  const rallies = await fetchMyActiveRallies(userId);
   if (rallies.length === 0) return <EmptyContent message="진행중인 랠리가 없어요!" />;
 
   return (

--- a/app/(info)/my/lib.ts
+++ b/app/(info)/my/lib.ts
@@ -1,0 +1,19 @@
+import { API_URL } from '@/lib/constants';
+import { purify } from '@/lib/either';
+import { resolveJson, validResponse } from '@/lib/response';
+import { MyRally } from '@/types/Rally';
+import { pipe, prop } from '@fxts/core';
+import { notFound } from 'next/navigation';
+
+export const fetchMyRallies = (userId: string) =>
+  pipe(
+    userId,
+    getMyRalliesApi, // API 주소 생성
+    fetch, // API 요청
+    validResponse, // HTTP 상태코드 검사
+    purify(notFound), // 404 에러 처리
+    resolveJson<{ data: MyRally[] }>, // JSON 파싱
+    prop('data')<{ data: MyRally[] }>, // 데이터 추출
+  );
+
+const getMyRalliesApi = (userId: string) => `${API_URL}/api/my/rallies?userId=${userId}`;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -22,6 +22,11 @@ const config = {
         primary: {
           DEFAULT: 'hsl(var(--primary))',
           foreground: 'hsl(var(--primary-foreground))',
+          100: '#FFDCCD',
+          200: '#FFBD9F',
+          300: '#FFAE8B',
+          400: '#FFAE8B',
+          500: '#FF7031',
         },
         secondary: {
           DEFAULT: 'hsl(var(--secondary))',


### PR DESCRIPTION
## 작업 내용

관련 이슈: #173 #207 #208 
종료한 랠리 페이지에서
- 완주/실패했는지에 대한 상태를 나타내는 요소를 추가했습니다.
- 완주한 랠리만 볼 수 있는 요소를 추가했습니다.
#207 에서 merge 할 브랜치를 잘못 설정하여 [revert](#208) 후 다시 merge 합니다.

https://github.com/user-attachments/assets/600e30dc-a1fd-4f31-8ae9-52435926555f


## 테스트 내용

- `/my/completes` 에 접속합니다.
- [ ] 완주/실패했는지에 대한 상태가 올바르게 나타납니다.
- [ ] 완주한 랠리만 보여지도록 체크합니다.
- [ ] 완주한 랠리만 보여집니다.
- [ ] 모든 종료된 랠리를 볼 수 있도록 체크를 해제합니다.
- [ ] 모든 랠리가 보여집니다.

### 리뷰어에게
#### 리뷰하기 전

`app/(info)/my/completes/page.tsx` 와 관련된 파일 위주로 리뷰 부탁 드립니다.

### 체크리스트

- [ ] 리뷰하는데 20분 이상 필요한가요? _20분 초과할 경우, 예상 리뷰 시간을 덧붙여주세요_
- [x] 셀프 리뷰를 진행했습니다.
- [x] 커밋 메세지를 컨벤션에 맞게 작성했습니다.
- [x] 테스트 내용에 기재된 항목에 대해서 실제로 테스트를 진행하고 동작을 확인했습니다.
