### PR TITLE
#215 랠리 연장 기능 로직 완성

### DIFF
--- a/app/(back)/rallies/[id]/actions.ts
+++ b/app/(back)/rallies/[id]/actions.ts
@@ -1,6 +1,15 @@
 'use server';
 
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { ensureMember } from '@/auth';
+import { API_URL } from '@/lib/constants';
+
 export const extendRally = async (form: FormData) => {
-  const id = form.get('id');
-  console.log(`Rally ${id} extended`);
+  const { id: userId } = await ensureMember();
+  const rallyId = form.get('id');
+
+  fetch(`${API_URL}/api/rallies/${rallyId}/extend`, { method: 'PATCH', body: JSON.stringify({ userId }) });
+  revalidatePath(`/rallies/${rallyId}`);
+  redirect(`/rallies/${rallyId}`);
 };

--- a/app/(back)/rallies/[id]/lib.ts
+++ b/app/(back)/rallies/[id]/lib.ts
@@ -45,7 +45,7 @@ const parseRallyDates: (fetched: FetchedRallyData) => FetchRallyData = evolve({
   }),
 });
 
-interface GetRallyInfoProps extends Pick<FetchRallyData, 'status' | 'completionDate' | 'extendedDueDate'> {
+interface GetRallyInfoProps extends Pick<FetchRallyData, 'status' | 'completionDate' | 'dueDate' | 'extendedDueDate'> {
   stamps: FetchRallyData['kit']['stamps'];
   starterId: FetchRallyData['starter']['id'];
   kitDeletedAt: FetchRallyData['kit']['deletedAt'];
@@ -59,7 +59,8 @@ export const getRallyInfo = (data: GetRallyInfoProps) =>
     derive('failed')(isFailed), // 실패 여부
     derive('extendable')(isNeverExtendedBefore), // 연장 가능 여부
     derive('startable')(isKitExist), // 시작 가능 여부
-    remain(['owned', 'total', 'failed', 'extendable', 'startable'] as const), // 필요한 값만 남기기
+    derive('deadline')(({ dueDate, extendedDueDate }) => extendedDueDate ?? dueDate), // 마감일
+    remain(['owned', 'total', 'failed', 'extendable', 'startable', 'deadline'] as const), // 필요한 값만 남기기
   );
 const isFailed = <T extends GetRallyInfoProps>(e: T) => pipe(e, juxt([isInactive, notCompleted]), every(Boolean));
 const isInactive = (e: GetRallyInfoProps) => pipe(e, prop('status'), eq(RallyStatus.inactive));

--- a/app/(back)/rallies/[id]/page.tsx
+++ b/app/(back)/rallies/[id]/page.tsx
@@ -6,6 +6,8 @@ import RallyFooter from './components/RallyFooter';
 import { RallyPageProps } from './types';
 import ExtendModal from './components/ExtendModal';
 
+export const revalidate = 1;
+
 export default async function RallyPage({ params: { id } }: RallyPageProps) {
   const viewerId = (await getMember())?.id;
   const {

--- a/app/(back)/rallies/[id]/page.tsx
+++ b/app/(back)/rallies/[id]/page.tsx
@@ -12,7 +12,7 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
     title,
     status,
     stampable,
-    dueDate: deadline,
+    dueDate,
     createdAt,
     updatedAt,
     completionDate,
@@ -21,13 +21,14 @@ export default async function RallyPage({ params: { id } }: RallyPageProps) {
     starter: { id: starterId },
     kit: { id: kitId, stamps, rewardImage, deletedAt: kitDeletedAt },
   } = await getRallyData(id);
-  const { owned, total, failed, extendable, startable } = getRallyInfo({
+  const { deadline, owned, total, failed, extendable, startable } = getRallyInfo({
     status,
     completionDate,
     stamps,
     starterId,
     viewerId,
     kitDeletedAt,
+    dueDate,
     extendedDueDate,
   });
 

--- a/app/api/lib/utils.ts
+++ b/app/api/lib/utils.ts
@@ -7,6 +7,7 @@ import { kitSelect, prisma } from '@/app/api/lib/prisma';
 import { SortOrder } from '@/app/api/lib/types';
 import { PAGE_SIZE } from './constants';
 import { pipe, prop } from '@fxts/core';
+import { RallyData } from '@/types/Rally';
 
 export const extractImageIdFromUrl = (url: string) => url.substring(url.lastIndexOf('/') + 1, url.lastIndexOf('?'));
 export const getStampsCreate = (keys: string[]) => ({
@@ -122,3 +123,9 @@ export const getAll =
 export const parseTake = (take: string | null) => parseInt(take ?? '') || PAGE_SIZE;
 /** URL에서 쿼리를 추출합니다. */
 export const getSearchParams = (request: NextRequest) => pipe(request, prop('nextUrl'), prop('searchParams'));
+/** 랠리의 상태 업데이트가 필요한 경우인지 확인합니다. */
+export const isActiveAndOverDue = ({ status, dueDate, extendedDueDate }: Pick<RallyData, 'status' | 'dueDate' | 'extendedDueDate'>) =>
+  (status === RallyStatus.active && // 진행중인 랠리이고
+    dueDate &&
+    dueDate.getTime() < Date.now()) || // 기한이 지났거나
+  (extendedDueDate && extendedDueDate.getTime() < Date.now()); /* 연장된 기한마저 지났을 경우 */

--- a/app/api/rallies/[id]/extend/route.ts
+++ b/app/api/rallies/[id]/extend/route.ts
@@ -1,17 +1,15 @@
 import { BadRequestError, NotFoundRallyError, ServerError, UnauthorizedError } from '@/app/api/lib/errors';
-import { prisma, rallySelect } from '@/app/api/lib/prisma';
-import { auth } from '@/auth';
+import { prisma } from '@/app/api/lib/prisma';
+import { RallyStatus } from '@prisma/client';
 import { NextResponse } from 'next/server';
 type PatchRallyParams = { params: { id: string } };
 
 // NOTE: 랠리 연장 API
 export async function PATCH(request: Request, { params }: PatchRallyParams) {
-  const session = await auth();
-  const currentUser = session?.user;
-
   const { id: rallyId } = params;
+  const { userId } = await request.json();
 
-  if (!currentUser) return UnauthorizedError;
+  if (!userId) return UnauthorizedError;
 
   try {
     const rally = await prisma.rally.findUnique({
@@ -20,16 +18,17 @@ export async function PATCH(request: Request, { params }: PatchRallyParams) {
     });
 
     if (!rally) return NotFoundRallyError;
+    if (userId !== rally.starterId) return UnauthorizedError;
     if (rally.extendedDueDate || !rally.dueDate) return BadRequestError;
 
     const remainStamp = rally.kit._count.stamps - rally.stampCount;
-    const extendedDueDate = new Date(rally.dueDate);
+    const extendedDueDate = new Date();
 
     extendedDueDate.setDate(extendedDueDate.getDate() + remainStamp);
 
     const updatedRally = await prisma.rally.update({
       where: { id: rallyId },
-      data: { extendedDueDate },
+      data: { extendedDueDate, status: RallyStatus.active },
     });
     return NextResponse.json({ data: updatedRally }, { status: 200 });
   } catch (error) {


### PR DESCRIPTION
## 작업 내용

관련 이슈: #215 
랠리 연장 기능 로직을 완성하고 API 와 연결했습니다.

## 테스트 내용

- [ ] 기한이 지났고 연장했던 적이 없는 랠리의 기한을 연장할 수 있습니다.
- [ ] 기한이 지난 랠리의 페이지에 접속합니다.
- [ ] 기한이 지난 랠리의 페이지의 모달창에서 '기한 연장하기' 버튼을 클릭합니다.
- [ ] 연장 요청 날짜로부터 남은 스탬프의 개수만큼 기한이 추가됩니다.

### 리뷰어에게

서버 로직에 약간의 수정이 있었습니다. 주석으로 수정한 이유를 달아둘테니 이에 오류가 있다고 생각하시면 편하게 수정 요청 부탁 드립니다.

### 체크리스트

- [ ] 리뷰하는데 20분 이상 필요한가요? _20분 초과할 경우, 예상 리뷰 시간을 덧붙여주세요_
- [x] 셀프 리뷰를 진행했습니다.
- [x] 커밋 메세지를 컨벤션에 맞게 작성했습니다.
- [x] 테스트 내용에 기재된 항목에 대해서 실제로 테스트를 진행하고 동작을 확인했습니다.
