### PR TITLE
#218 랠리 포기 기능 완성

### DIFF
--- a/app/(back)/rallies/[id]/@modal/(.)delete/actions.ts
+++ b/app/(back)/rallies/[id]/@modal/(.)delete/actions.ts
@@ -1,11 +1,12 @@
 'use server';
 
+import { redirect } from 'next/navigation';
 import { ensureMember } from '@/auth';
+import { API_URL } from '@/lib/constants';
 
 export const deleteRally = async (form: FormData) => {
   const userId = (await ensureMember()).id;
   const rallyId = form.get('id') as string;
-
-  console.log(`Deleting rally ${rallyId} for user ${userId}`);
-  console.log(`TODO: Implement rally deletion`);
+  fetch(`${API_URL}/api/rallies/${rallyId}`, { method: 'DELETE', body: JSON.stringify({ userId }) });
+  redirect(`/rallies`);
 };

--- a/app/(back)/rallies/[id]/@modal/(.)delete/page.tsx
+++ b/app/(back)/rallies/[id]/@modal/(.)delete/page.tsx
@@ -8,6 +8,7 @@ export default async function DeleteRallyModal({ params: { id } }: RallyPageProp
   const { title, description } = await getTexts(id);
   return (
     <Modal back={`/rallies/${id}`} labels={{ submit: '포기하기', cancel: '뒤로가기' }} onSubmit={deleteRally}>
+      <input type="hidden" name="id" value={id} />
       <SadCat className="size-18 m-auto" />
       <ModalTitle>{title}</ModalTitle>
       <ModalDescription>{description}</ModalDescription>

--- a/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
+++ b/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
@@ -4,13 +4,16 @@ import { extendRally } from '../../actions';
 import { getExtendModalInfo } from './lib';
 
 interface ExtendModalProps {
+  owned: boolean;
+  failed: boolean;
   id: string;
   kitId: string;
   extendable: boolean;
   startable: boolean;
 }
 
-export default async function ExtendModal({ id, kitId, extendable, startable }: ExtendModalProps) {
+export default async function ExtendModal({ owned, failed, id, kitId, extendable, startable }: ExtendModalProps) {
+  if (!owned || !failed) return null;
   const { description, labels, cancel } = getExtendModalInfo({ kitId, extendable, startable });
   return (
     <Modal back="/rallies" cancel={cancel} labels={labels} onSubmit={extendRally} className="px-4">

--- a/app/(back)/rallies/[id]/components/RallyFooter.tsx
+++ b/app/(back)/rallies/[id]/components/RallyFooter.tsx
@@ -7,19 +7,19 @@ import { getFooterConditions, getFooterVariant, getFooterContent, getFooterStyle
 import { RallyFooterInfo } from './types';
 
 interface RallyFooterProps extends RallyFooterInfo {
-  rallyId: string;
+  id: string;
 }
 
 export default function RallyFooter(props: RallyFooterProps) {
   const router = useRouter();
-  const rallyId = props.rallyId;
+  const id = props.id;
 
   const content = getFooterContent(props);
   const is = getFooterVariant(getFooterConditions(props));
   const styles = getFooterStyles(is);
 
   const onClick = async () => {
-    const response = await fetch(`/api/rallies/${rallyId}/stamp`, {
+    const response = await fetch(`/api/rallies/${id}/stamp`, {
       method: 'PATCH',
       body: JSON.stringify({ stampCount: props.count }),
     });

--- a/app/(back)/rallies/[id]/layout.tsx
+++ b/app/(back)/rallies/[id]/layout.tsx
@@ -8,13 +8,17 @@ interface RallyLayoutProps extends RallyPageProps {
 }
 
 export async function generateMetadata({ params: { id } }: RallyLayoutProps): Promise<Metadata> {
-  const {
-    title,
-    starter: { name },
-  } = await getRallyData(id);
-  return {
-    title: `${name}님의 ${title} 랠리`,
-  };
+  try {
+    const {
+      title,
+      starter: { name },
+    } = await getRallyData(id);
+    return {
+      title: `${name}님의 ${title} 랠리`,
+    };
+  } catch (e) {
+    return { title: '랠리' };
+  }
 }
 
 export default function RallyLayout({ children, modal }: RallyLayoutProps) {

--- a/app/(back)/rallies/[id]/lib.ts
+++ b/app/(back)/rallies/[id]/lib.ts
@@ -32,14 +32,9 @@ const parseRallyDates: (fetched: FetchedRallyData) => FetchRallyData = evolve({
   }),
 });
 
-interface GetRallyInfoProps extends Pick<FetchRallyData, 'status' | 'completionDate' | 'dueDate' | 'extendedDueDate'> {
-  stamps: FetchRallyData['kit']['stamps'];
-  starterId: FetchRallyData['starter']['id'];
-  kitDeletedAt: FetchRallyData['kit']['deletedAt'];
 export const flattenRallyData = (data: FetchRallyData) =>
   pipe(
     data,
-    bind('deadline', flats['deadline']),
     bind('count', flats['count']),
     bind('starterId', flats['starterId']),
     bind('kitId', flats['kitId']),
@@ -49,7 +44,6 @@ export const flattenRallyData = (data: FetchRallyData) =>
   );
 
 const flats = {
-  deadline: ({ dueDate }: { dueDate: FetchRallyData['dueDate'] }) => dueDate,
   count: ({ stampCount }: { stampCount: FetchRallyData['stampCount'] }) => stampCount,
   starterId: ({ starter: { id } }: FetchRallyData) => id,
   kitId: ({ kit: { id } }: FetchRallyData) => id,
@@ -69,6 +63,7 @@ export const appendRallyInfo = (data: AppendRallyInfoProps) =>
     bind('failed', appends['failed']),
     bind('extendable', appends['extendable']),
     bind('startable', appends['startable']),
+    bind('deadline', appends['deadline']),
   );
 const appends = {
   // 소유 여부: starterId와 viewerId가 같은지
@@ -81,6 +76,8 @@ const appends = {
   extendable: ({ extendedDueDate }: AppendRallyInfoProps) => extendedDueDate === null,
   // 시작 가능 여부: 키트가 삭제된 경우(키트 삭제일이 있는 경우)
   startable: ({ kitDeletedAt }: AppendRallyInfoProps) => kitDeletedAt !== null,
+  // 마감일: 연장 기한이 있는 경우 연장 기한, 없는 경우 마감일
+  deadline: ({ dueDate, extendedDueDate }: AppendRallyInfoProps) => extendedDueDate ?? dueDate,
 } as const;
 
 export interface GetRallyDatesProps extends Pick<FetchRallyData, 'createdAt' | 'updatedAt' | 'status' | 'completionDate'> {

--- a/app/(back)/rallies/[id]/page.tsx
+++ b/app/(back)/rallies/[id]/page.tsx
@@ -7,6 +7,8 @@ import { RallyPageProps } from './types';
 import ExtendModal from './components/ExtendModal';
 import { notFound } from 'next/navigation';
 
+export const revalidate = 1;
+
 export default async function RallyPage({ params: { id } }: RallyPageProps) {
   const viewerId = (await getMember())?.id;
   const raw = await getRallyData(id);

--- a/app/(back)/rallies/[id]/page.tsx
+++ b/app/(back)/rallies/[id]/page.tsx
@@ -1,59 +1,24 @@
 import { getMember } from '@/auth';
-import { getRallyData, getRallyInfo } from './lib';
+import { appendRallyInfo, flattenRallyData, getRallyData } from './lib';
 import RallyInfo from './components/RallyInfo';
 import RallyStamps from './components/RallyStamps';
 import RallyFooter from './components/RallyFooter';
 import { RallyPageProps } from './types';
 import ExtendModal from './components/ExtendModal';
+import { notFound } from 'next/navigation';
 
 export default async function RallyPage({ params: { id } }: RallyPageProps) {
   const viewerId = (await getMember())?.id;
-  const {
-    title,
-    status,
-    stampable,
-    dueDate: deadline,
-    createdAt,
-    updatedAt,
-    completionDate,
-    extendedDueDate,
-    stampCount: count,
-    starter: { id: starterId },
-    kit: { id: kitId, stamps, rewardImage, deletedAt: kitDeletedAt },
-  } = await getRallyData(id);
-  const { owned, total, failed, extendable, startable } = getRallyInfo({
-    status,
-    completionDate,
-    stamps,
-    starterId,
-    viewerId,
-    kitDeletedAt,
-    extendedDueDate,
-  });
-
+  const raw = await getRallyData(id);
+  raw.title ?? notFound();
+  const data = flattenRallyData(raw);
+  const info = appendRallyInfo({ ...data, viewerId });
   return (
     <main className="px-4 py-6 w-full bg-grey-50 flex flex-col gap-6">
-      <RallyInfo
-        title={title}
-        status={status}
-        count={count}
-        total={total}
-        createdAt={createdAt}
-        updatedAt={updatedAt}
-        deadline={deadline}
-        completionDate={completionDate}
-      />
-      <RallyStamps
-        owned={owned}
-        stamps={stamps}
-        count={count}
-        total={total}
-        stampable={stampable}
-        rewardImage={rewardImage}
-        completionDate={completionDate}
-      />
-      <RallyFooter owned={owned} status={status} count={count} total={total} stampable={stampable} rallyId={id} />
-      {owned && failed && <ExtendModal id={id} kitId={kitId} extendable={extendable} startable={startable} />}
+      <RallyInfo {...info} />
+      <RallyStamps {...info} />
+      <RallyFooter {...info} />
+      <ExtendModal {...info} />
     </main>
   );
 }

--- a/app/api/rallies/[id]/route.ts
+++ b/app/api/rallies/[id]/route.ts
@@ -28,11 +28,12 @@ export async function GET(_: Request, { params }: GetRallyParams) {
   }
 }
 
-export async function DELETE(_: Request, { params }: DeleteRallyParams) {
+export async function DELETE(req: Request, { params }: DeleteRallyParams) {
   const { id } = params;
+  const { userId } = await req.json();
 
   try {
-    const rally = await prisma.rally.findUnique({ where: { id, deletedAt: null } });
+    const rally = await prisma.rally.findUnique({ where: { id, deletedAt: null, starterId: userId } });
 
     if (!rally) NotFoundRallyError;
 
@@ -43,6 +44,7 @@ export async function DELETE(_: Request, { params }: DeleteRallyParams) {
 
     return NextResponse.json({ data: deletedRally }, { status: 200 });
   } catch (error) {
+    console.error(error);
     return ServerError;
   }
 }

--- a/components/BackHeader/components/lib.ts
+++ b/components/BackHeader/components/lib.ts
@@ -1,19 +1,14 @@
-import { purify } from '@/lib/either';
-import { resolveJson, validResponse } from '@/lib/response';
-import { FetchedRallyData } from '@/types/Rally';
-import { pipe } from '@fxts/core';
-import { notFound } from 'next/navigation';
+import { fetchData } from '@/lib/response';
 import { useEffect, useState } from 'react';
 
 export const extractId = (path: string) => /\/(rallies|kits)\/(\w+)/.exec(path)?.[2] ?? '';
 
-export function useRallyStarterId(id: string) {
-  const [data, setData] = useState<FetchedRallyData | null>(null);
+export function useRallyStarterId(rallyId: string) {
+  const [starterId, setStarterId] = useState<string | null>(null);
   useEffect(() => {
-    getRallyData(id).then(({ data }) => setData(data));
-  }, [id]);
-  return data?.starter?.id;
+    fetchData<{ starter: { id: string } }>(`/api/rallies/${rallyId}`) //
+      .then(({ starter: { id } }) => setStarterId(id))
+      .catch(() => setStarterId(null));
+  }, [rallyId]);
+  return starterId;
 }
-
-const getRallyData = async (id: string) =>
-  pipe(id, (id) => `/api/rallies/${id}`, fetch, validResponse, purify(notFound), resolveJson<{ data: FetchedRallyData }>);

--- a/components/BackHeader/lib.ts
+++ b/components/BackHeader/lib.ts
@@ -26,9 +26,9 @@ function getTitleFromPath(path: string) {
   // /kits/[id]/start
   if (TITLE_MAP.get('rally-start')!.test(path)) return '랠리 시작하기';
   // /kits/[id]
-  if (TITLE_MAP.get('kit')!.test(path)) return '스탬프 랠리';
+  if (TITLE_MAP.get('kit')!.test(path)) return '스탬프 키트';
   // /rallies/[id]
-  if (TITLE_MAP.get('rally-ongoing')!.test(path)) return '스탬프 랠리 진행중';
+  if (TITLE_MAP.get('rally-ongoing')!.test(path)) return '스탬프 랠리';
   // /rallies
   if (TITLE_MAP.get('rallies')!.test(path)) return '진행중인 랠리';
   // 경로의 제목이 정의되지 않은 경우

--- a/lib/response.ts
+++ b/lib/response.ts
@@ -7,7 +7,5 @@ export const validOrNotFound = (res: Response) => purify<Response, Response>(not
 export const resolveText = (res: Response | Request) => res.text();
 export const resolveJson = <T>(res: Response | Request): Promise<T> => res.json();
 export const resolveData = <T>(res: Response | Request) => res.json().then(({ data }) => data as T);
-export const fetchDataOrNotFound = <T>(...props: Parameters<typeof fetch>): Promise<T> =>
-  fetch(...props)
-    .then(resolveData<T>)
-    .catch(notFound);
+export const fetchData = <T>(...props: Parameters<typeof fetch>): Promise<T> => fetch(...props).then(resolveData<T>);
+export const fetchDataOrNotFound = <T>(...props: Parameters<typeof fetch>): Promise<T> => fetchData<T>(...props).catch(notFound);

--- a/lib/response.ts
+++ b/lib/response.ts
@@ -7,7 +7,7 @@ export const validOrNotFound = (res: Response) => purify<Response, Response>(not
 export const resolveText = (res: Response | Request) => res.text();
 export const resolveJson = <T>(res: Response | Request): Promise<T> => res.json();
 export const resolveData = <T>(res: Response | Request) => res.json().then(({ data }) => data as T);
-export const fetchDataOrNotFound = <T>(...props: Parameters<typeof fetch>) =>
+export const fetchDataOrNotFound = <T>(...props: Parameters<typeof fetch>): Promise<T> =>
   fetch(...props)
-    .then(validOrNotFound)
-    .then(resolveData<T>);
+    .then(resolveData<T>)
+    .catch(notFound);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev:clean": "rm -rf .next/ && next dev",
     "build": "yarn add sharp --ignore-engines && prisma generate && next build",
     "start": "next start",
+    "bs": "next build && next start",
     "lint": "next lint"
   },
   "prisma": {


### PR DESCRIPTION
## 작업 내용

관련 이슈: #218 
랠리 포기 기능을 완성합니다.

## 테스트 내용

- [ ] 자신이 소유한 랠리 페이지에 접속하면 헤더 우측에 쓰레기통 모양의 포기 버튼이 보입니다.
  ![image](https://github.com/user-attachments/assets/6b6cd6c9-d2b8-465b-bd76-0c791db46c6f)
  - [ ] 자신이 소유하지 않은 랠리 페이지에서는 포기 버튼이 보이지 않습니다.
- [ ] 포기 버튼을 클릭하면 랠리 포기 모달이 나타납니다.
  ![image](https://github.com/user-attachments/assets/5b161444-1b7d-4ecf-800e-2d7aa8060139)
- [ ] 포기 모달의 `포기하기` 버튼을 누르면 랠리가 포기됩니다.
- [ ] 포기한 랠리의 페이지에 접속하면 404 오류 페이지가 나옵니다.


### 리뷰어에게

`app/(back)/rallies/[id]/@modal/(.)delete/actions.ts` 위주로 리뷰 부탁 드립니다. 대부분 기존 코드 리팩토링입니다.

### 체크리스트

- [ ] 리뷰하는데 20분 이상 필요한가요? _20분 초과할 경우, 예상 리뷰 시간을 덧붙여주세요_
- [x] 셀프 리뷰를 진행했습니다.
- [x] 커밋 메세지를 컨벤션에 맞게 작성했습니다.
- [x] 테스트 내용에 기재된 항목에 대해서 실제로 테스트를 진행하고 동작을 확인했습니다.
