### PR TITLE
#178 키트 삭제 기능 완성

### DIFF
--- a/app/(back)/kits/[id]/@modal/(.)delete/actions.ts
+++ b/app/(back)/kits/[id]/@modal/(.)delete/actions.ts
@@ -1,0 +1,12 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { ensureMember } from '@/auth';
+import { API_URL } from '@/lib/constants';
+
+export const deleteKit = async (form: FormData) => {
+  const uploaderId = (await ensureMember()).id;
+  const kitId = form.get('id') as string;
+  fetch(`${API_URL}/api/kits/${kitId}`, { method: 'DELETE', body: JSON.stringify({ uploaderId }) });
+  redirect(`/my/uploads`);
+};

--- a/app/(back)/kits/[id]/@modal/(.)delete/page.tsx
+++ b/app/(back)/kits/[id]/@modal/(.)delete/page.tsx
@@ -1,0 +1,15 @@
+import Modal, { ModalDescription, ModalTitle } from '@/components/ParallelModal';
+import { SadCat } from '@/lib/icons';
+import { KitPageInfo } from '../../types';
+import { deleteKit } from './actions';
+
+export default async function DeleteRallyModal({ params: { id } }: KitPageInfo) {
+  return (
+    <Modal back={`/kits/${id}`} labels={{ submit: '삭제하기', cancel: '뒤로가기' }} onSubmit={deleteKit}>
+      <input type="hidden" name="id" value={id} />
+      <SadCat className="size-18 m-auto" />
+      <ModalTitle>정말 키트를 삭제하시겠어요?</ModalTitle>
+      <ModalDescription>키트 삭제 시 해당 키트로 랠리가 진행 불가능하며 복구가 불가능해요!</ModalDescription>
+    </Modal>
+  );
+}

--- a/app/(back)/kits/[id]/@modal/page.tsx
+++ b/app/(back)/kits/[id]/@modal/page.tsx
@@ -1,0 +1,3 @@
+import { constNull } from '@/lib/always';
+
+export default constNull;

--- a/app/(back)/kits/[id]/delete/page.tsx
+++ b/app/(back)/kits/[id]/delete/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation';
+import { KitPageInfo } from '../types';
+
+export default function DeleteRallyPage({ params: { id } }: KitPageInfo) {
+  return redirect(`/kits/${id}`);
+}

--- a/app/(back)/kits/[id]/layout.tsx
+++ b/app/(back)/kits/[id]/layout.tsx
@@ -3,18 +3,8 @@ import { KitPageInfo } from './types';
 import { getKitData } from './lib';
 
 export async function generateMetadata({ params: { id } }: KitPageInfo): Promise<Metadata> {
-  const {
-    data: {
-      title,
-      uploader: { name },
-    },
-  } = await getKitData(id);
-  return {
-    title: {
-      absolute: `꾹꾹 | ${name}님의 ${title} 키트`,
-      template: `꾹꾹 | ${name}님의 ${title} 키트%s`,
-    },
-  };
+  const kit = await getKitData(id);
+  return { title: kit ? `${kit.uploader.name}님의 ${kit.title} 키트` : `찾을 수 없는 키트` };
 }
 export default async function KitLayout({ children, modal }: { children: React.ReactNode; modal: React.ReactNode }) {
   return (

--- a/app/(back)/kits/[id]/layout.tsx
+++ b/app/(back)/kits/[id]/layout.tsx
@@ -16,6 +16,11 @@ export async function generateMetadata({ params: { id } }: KitPageInfo): Promise
     },
   };
 }
-export default async function KitLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+export default async function KitLayout({ children, modal }: { children: React.ReactNode; modal: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      {modal}
+    </>
+  );
 }

--- a/app/(back)/kits/[id]/lib.ts
+++ b/app/(back)/kits/[id]/lib.ts
@@ -1,14 +1,12 @@
-import { notFound } from 'next/navigation';
 import { KitData } from '@/types/Kit';
+import { API_URL } from '@/lib/constants';
 import { S3Manager } from '@/lib/services/s3';
-import { StampData } from '@/types/Stamp';
-import { addBase64Prefix, convertResponseToArrayBuffer, convertBufferToBase64 } from '@/lib/utils';
 import { cropImage320by320 } from '@/lib/sharp';
+import { fetchData } from '@/lib/response';
+import { addBase64Prefix, convertResponseToArrayBuffer, convertBufferToBase64 } from '@/lib/utils';
+import { StampData } from '@/types/Stamp';
 
-export const getKitData = (id: string): Promise<{ data: KitData }> =>
-  fetch(`${process.env.API_URL}/api/kits/${id}`)
-    .then((res) => res.json())
-    .catch(() => notFound());
+export const getKitData = (id: string) => fetchData<KitData>(`${API_URL}/api/kits/${id}`).catch(() => null);
 
 export const openGraphSizes = {
   image: 320,

--- a/app/(back)/kits/[id]/opengraph-image.tsx
+++ b/app/(back)/kits/[id]/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from 'next/og';
 import OpenGraph from './components/OpenGraph';
 import { getKitData, addSrcToStamps, openGraphSizes as sizes } from './lib';
+import { notFound } from 'next/navigation';
 
 export const alt = '꾹꾹 키트';
 export const size = {
@@ -11,7 +12,7 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image({ params: { id } }: { params: { id: string } }) {
-  const { data: kit } = await getKitData(id);
+  const kit = (await getKitData(id)) ?? notFound();
   const srcs = await addSrcToStamps(kit.stamps);
 
   return new ImageResponse(<OpenGraph srcs={srcs} />, { ...size });

--- a/app/(back)/kits/[id]/page.tsx
+++ b/app/(back)/kits/[id]/page.tsx
@@ -4,24 +4,16 @@ import RallyPreview from './components/RallyPreview';
 import StampsPreview from './components/StampsPreview';
 import { getKitData } from './lib';
 import { KitPageInfo } from './types';
+import { notFound } from 'next/navigation';
 
 interface KitPageProps extends KitPageInfo {}
 
 export default async function KitPage({ params: { id } }: KitPageProps) {
-  const { data: kit } = await getKitData(id);
-  const { title, description, tags, thumbnailImage, uploader, stamps } = kit;
+  const { description, stamps, ...kit } = (await getKitData(id)) ?? notFound();
 
   return (
     <main className="w-full grid grid-cols-1">
-      <KitCard
-        id={id}
-        title={title}
-        description={description || ''}
-        tags={tags}
-        thumbnailImage={thumbnailImage}
-        uploader={uploader}
-        variant={KitCardVariants.description}
-      />
+      <KitCard {...kit} description={description ?? ''} variant={KitCardVariants.description} />
       <RallyPreview stamps={stamps} />
       <StampsPreview stamps={stamps} />
       <section className="flex justify-center px-4 pb-6 bg-grey-50">

--- a/app/(back)/kits/[id]/start/page.tsx
+++ b/app/(back)/kits/[id]/start/page.tsx
@@ -4,6 +4,7 @@ import KitCard, { KitCardVariants } from '@/components/KitCard';
 import RallyStartForm from './components/RallyStartForm';
 import { getKitData } from '../lib';
 import { KitPageInfo } from '../types';
+import { notFound } from 'next/navigation';
 
 export const metadata: Metadata = {
   title: { absolute: `꾹꾹 | 랠리 시작하기` },
@@ -11,20 +12,11 @@ export const metadata: Metadata = {
 
 export default async function RallyStartPage({ params: { id } }: KitPageInfo) {
   const { id: userId } = await ensureMember();
-  const { data: kit } = await getKitData(id);
-  const { title, description, tags, thumbnailImage, uploader } = kit;
+  const { description, ...kit } = (await getKitData(id)) ?? notFound();
 
   return (
     <main className="w-full py-6 px-4 flex flex-col gap-6">
-      <KitCard
-        variant={KitCardVariants.StartPage}
-        id={id}
-        title={title}
-        description={description || ''}
-        tags={tags}
-        thumbnailImage={thumbnailImage}
-        uploader={uploader}
-      />
+      <KitCard {...kit} description={description || ''} variant={KitCardVariants.StartPage} />
       <RallyStartForm starterId={userId} kitId={id} />
     </main>
   );

--- a/app/(back)/rallies/[id]/@modal/(.)delete/actions.ts
+++ b/app/(back)/rallies/[id]/@modal/(.)delete/actions.ts
@@ -1,11 +1,12 @@
 'use server';
 
+import { redirect } from 'next/navigation';
 import { ensureMember } from '@/auth';
+import { API_URL } from '@/lib/constants';
 
 export const deleteRally = async (form: FormData) => {
   const userId = (await ensureMember()).id;
   const rallyId = form.get('id') as string;
-
-  console.log(`Deleting rally ${rallyId} for user ${userId}`);
-  console.log(`TODO: Implement rally deletion`);
+  fetch(`${API_URL}/api/rallies/${rallyId}`, { method: 'DELETE', body: JSON.stringify({ userId }) });
+  redirect(`/rallies`);
 };

--- a/app/(back)/rallies/[id]/@modal/(.)delete/page.tsx
+++ b/app/(back)/rallies/[id]/@modal/(.)delete/page.tsx
@@ -8,6 +8,7 @@ export default async function DeleteRallyModal({ params: { id } }: RallyPageProp
   const { title, description } = await getTexts(id);
   return (
     <Modal back={`/rallies/${id}`} labels={{ submit: '포기하기', cancel: '뒤로가기' }} onSubmit={deleteRally}>
+      <input type="hidden" name="id" value={id} />
       <SadCat className="size-18 m-auto" />
       <ModalTitle>{title}</ModalTitle>
       <ModalDescription>{description}</ModalDescription>

--- a/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
+++ b/app/(back)/rallies/[id]/components/ExtendModal/index.tsx
@@ -4,13 +4,16 @@ import { extendRally } from '../../actions';
 import { getExtendModalInfo } from './lib';
 
 interface ExtendModalProps {
+  owned: boolean;
+  failed: boolean;
   id: string;
   kitId: string;
   extendable: boolean;
   startable: boolean;
 }
 
-export default async function ExtendModal({ id, kitId, extendable, startable }: ExtendModalProps) {
+export default async function ExtendModal({ owned, failed, id, kitId, extendable, startable }: ExtendModalProps) {
+  if (!owned || !failed) return null;
   const { description, labels, cancel } = getExtendModalInfo({ kitId, extendable, startable });
   return (
     <Modal back="/rallies" cancel={cancel} labels={labels} onSubmit={extendRally} className="px-4">

--- a/app/(back)/rallies/[id]/components/RallyFooter.tsx
+++ b/app/(back)/rallies/[id]/components/RallyFooter.tsx
@@ -7,19 +7,19 @@ import { getFooterConditions, getFooterVariant, getFooterContent, getFooterStyle
 import { RallyFooterInfo } from './types';
 
 interface RallyFooterProps extends RallyFooterInfo {
-  rallyId: string;
+  id: string;
 }
 
 export default function RallyFooter(props: RallyFooterProps) {
   const router = useRouter();
-  const rallyId = props.rallyId;
+  const id = props.id;
 
   const content = getFooterContent(props);
   const is = getFooterVariant(getFooterConditions(props));
   const styles = getFooterStyles(is);
 
   const onClick = async () => {
-    const response = await fetch(`/api/rallies/${rallyId}/stamp`, {
+    const response = await fetch(`/api/rallies/${id}/stamp`, {
       method: 'PATCH',
       body: JSON.stringify({ stampCount: props.count }),
     });

--- a/app/(back)/rallies/[id]/layout.tsx
+++ b/app/(back)/rallies/[id]/layout.tsx
@@ -8,13 +8,17 @@ interface RallyLayoutProps extends RallyPageProps {
 }
 
 export async function generateMetadata({ params: { id } }: RallyLayoutProps): Promise<Metadata> {
-  const {
-    title,
-    starter: { name },
-  } = await getRallyData(id);
-  return {
-    title: `${name}님의 ${title} 랠리`,
-  };
+  try {
+    const {
+      title,
+      starter: { name },
+    } = await getRallyData(id);
+    return {
+      title: `${name}님의 ${title} 랠리`,
+    };
+  } catch (e) {
+    return { title: '랠리' };
+  }
 }
 
 export default function RallyLayout({ children, modal }: RallyLayoutProps) {

--- a/app/(back)/rallies/[id]/lib.ts
+++ b/app/(back)/rallies/[id]/lib.ts
@@ -32,14 +32,9 @@ const parseRallyDates: (fetched: FetchedRallyData) => FetchRallyData = evolve({
   }),
 });
 
-interface GetRallyInfoProps extends Pick<FetchRallyData, 'status' | 'completionDate' | 'dueDate' | 'extendedDueDate'> {
-  stamps: FetchRallyData['kit']['stamps'];
-  starterId: FetchRallyData['starter']['id'];
-  kitDeletedAt: FetchRallyData['kit']['deletedAt'];
 export const flattenRallyData = (data: FetchRallyData) =>
   pipe(
     data,
-    bind('deadline', flats['deadline']),
     bind('count', flats['count']),
     bind('starterId', flats['starterId']),
     bind('kitId', flats['kitId']),
@@ -49,7 +44,6 @@ export const flattenRallyData = (data: FetchRallyData) =>
   );
 
 const flats = {
-  deadline: ({ dueDate }: { dueDate: FetchRallyData['dueDate'] }) => dueDate,
   count: ({ stampCount }: { stampCount: FetchRallyData['stampCount'] }) => stampCount,
   starterId: ({ starter: { id } }: FetchRallyData) => id,
   kitId: ({ kit: { id } }: FetchRallyData) => id,
@@ -69,6 +63,7 @@ export const appendRallyInfo = (data: AppendRallyInfoProps) =>
     bind('failed', appends['failed']),
     bind('extendable', appends['extendable']),
     bind('startable', appends['startable']),
+    bind('deadline', appends['deadline']),
   );
 const appends = {
   // 소유 여부: starterId와 viewerId가 같은지
@@ -81,6 +76,8 @@ const appends = {
   extendable: ({ extendedDueDate }: AppendRallyInfoProps) => extendedDueDate === null,
   // 시작 가능 여부: 키트가 삭제된 경우(키트 삭제일이 있는 경우)
   startable: ({ kitDeletedAt }: AppendRallyInfoProps) => kitDeletedAt !== null,
+  // 마감일: 연장 기한이 있는 경우 연장 기한, 없는 경우 마감일
+  deadline: ({ dueDate, extendedDueDate }: AppendRallyInfoProps) => extendedDueDate ?? dueDate,
 } as const;
 
 export interface GetRallyDatesProps extends Pick<FetchRallyData, 'createdAt' | 'updatedAt' | 'status' | 'completionDate'> {

--- a/app/(back)/rallies/[id]/page.tsx
+++ b/app/(back)/rallies/[id]/page.tsx
@@ -7,6 +7,8 @@ import { RallyPageProps } from './types';
 import ExtendModal from './components/ExtendModal';
 import { notFound } from 'next/navigation';
 
+export const revalidate = 1;
+
 export default async function RallyPage({ params: { id } }: RallyPageProps) {
   const viewerId = (await getMember())?.id;
   const raw = await getRallyData(id);

--- a/app/(back)/rallies/[id]/page.tsx
+++ b/app/(back)/rallies/[id]/page.tsx
@@ -1,59 +1,24 @@
 import { getMember } from '@/auth';
-import { getRallyData, getRallyInfo } from './lib';
+import { appendRallyInfo, flattenRallyData, getRallyData } from './lib';
 import RallyInfo from './components/RallyInfo';
 import RallyStamps from './components/RallyStamps';
 import RallyFooter from './components/RallyFooter';
 import { RallyPageProps } from './types';
 import ExtendModal from './components/ExtendModal';
+import { notFound } from 'next/navigation';
 
 export default async function RallyPage({ params: { id } }: RallyPageProps) {
   const viewerId = (await getMember())?.id;
-  const {
-    title,
-    status,
-    stampable,
-    dueDate: deadline,
-    createdAt,
-    updatedAt,
-    completionDate,
-    extendedDueDate,
-    stampCount: count,
-    starter: { id: starterId },
-    kit: { id: kitId, stamps, rewardImage, deletedAt: kitDeletedAt },
-  } = await getRallyData(id);
-  const { owned, total, failed, extendable, startable } = getRallyInfo({
-    status,
-    completionDate,
-    stamps,
-    starterId,
-    viewerId,
-    kitDeletedAt,
-    extendedDueDate,
-  });
-
+  const raw = await getRallyData(id);
+  raw.title ?? notFound();
+  const data = flattenRallyData(raw);
+  const info = appendRallyInfo({ ...data, viewerId });
   return (
     <main className="px-4 py-6 w-full bg-grey-50 flex flex-col gap-6">
-      <RallyInfo
-        title={title}
-        status={status}
-        count={count}
-        total={total}
-        createdAt={createdAt}
-        updatedAt={updatedAt}
-        deadline={deadline}
-        completionDate={completionDate}
-      />
-      <RallyStamps
-        owned={owned}
-        stamps={stamps}
-        count={count}
-        total={total}
-        stampable={stampable}
-        rewardImage={rewardImage}
-        completionDate={completionDate}
-      />
-      <RallyFooter owned={owned} status={status} count={count} total={total} stampable={stampable} rallyId={id} />
-      {owned && failed && <ExtendModal id={id} kitId={kitId} extendable={extendable} startable={startable} />}
+      <RallyInfo {...info} />
+      <RallyStamps {...info} />
+      <RallyFooter {...info} />
+      <ExtendModal {...info} />
     </main>
   );
 }

--- a/app/api/kits/[id]/route.ts
+++ b/app/api/kits/[id]/route.ts
@@ -23,11 +23,15 @@ export async function GET(_: Request, { params }: GetKitParams) {
   }
 }
 
-export async function DELETE(_: Request, { params }: DeleteKitParams) {
+export async function DELETE(req: Request, { params }: DeleteKitParams) {
   const { id } = params;
+  const { uploaderId } = (await req.json()) as { uploaderId: string };
 
   try {
-    const kit = await prisma.kit.findUnique({ where: { id } });
+    const kit = await prisma.kit.update({
+      where: { id, uploaderId },
+      data: { deletedAt: new Date() },
+    });
 
     if (!kit) NotFoundKitError;
 

--- a/app/api/lib/prisma/selects.ts
+++ b/app/api/lib/prisma/selects.ts
@@ -52,10 +52,12 @@ export const userInfoSelect = {
   },
   rallies: {
     orderBy: { id: 'desc' },
+    where: { deletedAt: null },
     select: rallySelect,
   },
   kits: {
     orderBy: { id: 'desc' },
+    where: { deletedAt: null },
     select: kitSelect,
   },
 } satisfies Prisma.UserSelect;

--- a/app/api/rallies/[id]/route.ts
+++ b/app/api/rallies/[id]/route.ts
@@ -28,11 +28,12 @@ export async function GET(_: Request, { params }: GetRallyParams) {
   }
 }
 
-export async function DELETE(_: Request, { params }: DeleteRallyParams) {
+export async function DELETE(req: Request, { params }: DeleteRallyParams) {
   const { id } = params;
+  const { userId } = await req.json();
 
   try {
-    const rally = await prisma.rally.findUnique({ where: { id, deletedAt: null } });
+    const rally = await prisma.rally.findUnique({ where: { id, deletedAt: null, starterId: userId } });
 
     if (!rally) NotFoundRallyError;
 
@@ -43,6 +44,7 @@ export async function DELETE(_: Request, { params }: DeleteRallyParams) {
 
     return NextResponse.json({ data: deletedRally }, { status: 200 });
   } catch (error) {
+    console.error(error);
     return ServerError;
   }
 }

--- a/components/BackHeader/components/SettingMenu.tsx
+++ b/components/BackHeader/components/SettingMenu.tsx
@@ -2,14 +2,14 @@ import { useMember } from '@/hooks/use-user';
 import { OutlineTrash } from '@/lib/icons';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { extractId, useRallyStarterId } from './lib';
+import { extractId, useKitUploaderId, useRallyStarterId } from './lib';
 
 export default function SettingMenu() {
   const path = usePathname();
   const id = extractId(path);
   if (!id) return null;
   if (/\/rallies\/\w+/.test(path)) return <DeleteRallyButton id={id} />;
-  // if(/kits\/\w+/.test(path)) return <DeleteKitButton id={id} />;
+  if (/kits\/\w+/.test(path)) return <DeleteKitButton id={id} />;
   return null;
 }
 
@@ -19,6 +19,17 @@ function DeleteRallyButton({ id }: { id: string }) {
   if (starterId !== viewerId) return null;
   return (
     <Link href={`/rallies/${id}/delete`}>
+      <OutlineTrash className="w-6 h-6 fill-red-500 " />
+    </Link>
+  );
+}
+
+function DeleteKitButton({ id }: { id: string }) {
+  const viewerId = useMember()?.id;
+  const starterId = useKitUploaderId(id);
+  if (starterId !== viewerId) return null;
+  return (
+    <Link href={`/kits/${id}/delete`}>
       <OutlineTrash className="w-6 h-6 fill-red-500 " />
     </Link>
   );

--- a/components/BackHeader/components/lib.ts
+++ b/components/BackHeader/components/lib.ts
@@ -1,19 +1,14 @@
-import { purify } from '@/lib/either';
-import { resolveJson, validResponse } from '@/lib/response';
-import { FetchedRallyData } from '@/types/Rally';
-import { pipe } from '@fxts/core';
-import { notFound } from 'next/navigation';
+import { fetchData } from '@/lib/response';
 import { useEffect, useState } from 'react';
 
 export const extractId = (path: string) => /\/(rallies|kits)\/(\w+)/.exec(path)?.[2] ?? '';
 
-export function useRallyStarterId(id: string) {
-  const [data, setData] = useState<FetchedRallyData | null>(null);
+export function useRallyStarterId(rallyId: string) {
+  const [starterId, setStarterId] = useState<string | null>(null);
   useEffect(() => {
-    getRallyData(id).then(({ data }) => setData(data));
-  }, [id]);
-  return data?.starter?.id;
+    fetchData<{ starter: { id: string } }>(`/api/rallies/${rallyId}`) //
+      .then(({ starter: { id } }) => setStarterId(id))
+      .catch(() => setStarterId(null));
+  }, [rallyId]);
+  return starterId;
 }
-
-const getRallyData = async (id: string) =>
-  pipe(id, (id) => `/api/rallies/${id}`, fetch, validResponse, purify(notFound), resolveJson<{ data: FetchedRallyData }>);

--- a/components/BackHeader/components/lib.ts
+++ b/components/BackHeader/components/lib.ts
@@ -12,3 +12,13 @@ export function useRallyStarterId(rallyId: string) {
   }, [rallyId]);
   return starterId;
 }
+
+export function useKitUploaderId(rallyId: string) {
+  const [starterId, setUploaderId] = useState<string | null>(null);
+  useEffect(() => {
+    fetchData<{ uploader: { id: string } }>(`/api/kits/${rallyId}`) //
+      .then(({ uploader: { id } }) => setUploaderId(id))
+      .catch(() => setUploaderId(null));
+  }, [rallyId]);
+  return starterId;
+}

--- a/components/BackHeader/lib.ts
+++ b/components/BackHeader/lib.ts
@@ -26,9 +26,9 @@ function getTitleFromPath(path: string) {
   // /kits/[id]/start
   if (TITLE_MAP.get('rally-start')!.test(path)) return '랠리 시작하기';
   // /kits/[id]
-  if (TITLE_MAP.get('kit')!.test(path)) return '스탬프 랠리';
+  if (TITLE_MAP.get('kit')!.test(path)) return '스탬프 키트';
   // /rallies/[id]
-  if (TITLE_MAP.get('rally-ongoing')!.test(path)) return '스탬프 랠리 진행중';
+  if (TITLE_MAP.get('rally-ongoing')!.test(path)) return '스탬프 랠리';
   // /rallies
   if (TITLE_MAP.get('rallies')!.test(path)) return '진행중인 랠리';
   // 경로의 제목이 정의되지 않은 경우

--- a/lib/response.ts
+++ b/lib/response.ts
@@ -7,7 +7,5 @@ export const validOrNotFound = (res: Response) => purify<Response, Response>(not
 export const resolveText = (res: Response | Request) => res.text();
 export const resolveJson = <T>(res: Response | Request): Promise<T> => res.json();
 export const resolveData = <T>(res: Response | Request) => res.json().then(({ data }) => data as T);
-export const fetchDataOrNotFound = <T>(...props: Parameters<typeof fetch>): Promise<T> =>
-  fetch(...props)
-    .then(resolveData<T>)
-    .catch(notFound);
+export const fetchData = <T>(...props: Parameters<typeof fetch>): Promise<T> => fetch(...props).then(resolveData<T>);
+export const fetchDataOrNotFound = <T>(...props: Parameters<typeof fetch>): Promise<T> => fetchData<T>(...props).catch(notFound);

--- a/lib/response.ts
+++ b/lib/response.ts
@@ -7,7 +7,7 @@ export const validOrNotFound = (res: Response) => purify<Response, Response>(not
 export const resolveText = (res: Response | Request) => res.text();
 export const resolveJson = <T>(res: Response | Request): Promise<T> => res.json();
 export const resolveData = <T>(res: Response | Request) => res.json().then(({ data }) => data as T);
-export const fetchDataOrNotFound = <T>(...props: Parameters<typeof fetch>) =>
+export const fetchDataOrNotFound = <T>(...props: Parameters<typeof fetch>): Promise<T> =>
   fetch(...props)
-    .then(validOrNotFound)
-    .then(resolveData<T>);
+    .then(resolveData<T>)
+    .catch(notFound);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev:clean": "rm -rf .next/ && next dev",
     "build": "yarn add sharp --ignore-engines && prisma generate && next build",
     "start": "next start",
+    "bs": "next build && next start",
     "lint": "next lint"
   },
   "prisma": {


### PR DESCRIPTION
## 작업 내용

관련 이슈: #178 
키트 삭제 기능을 완성했습니다.

## 테스트 내용

- [ ] 자신이 올린 키트의 페이지로 접속하면 헤더 우측에 쓰레기통 모양의 키트 삭제 버튼이 보입니다.
  ![image](https://github.com/user-attachments/assets/6b6cd6c9-d2b8-465b-bd76-0c791db46c6f)
  - [ ] 자신이 소유하지 않은 키트 페이지에서는 삭제 버튼이 보이지 않습니다.
- [ ] 삭제 버튼을 클릭하면 키트 삭제 여부를 묻는 모달이 나타납니다.
  ![image](https://github.com/user-attachments/assets/da484065-6158-486f-b62b-99d869a16459)
- [ ] 삭제 모달의 `삭제하기` 버튼을 누르면 키트가 삭제됩니다.
- [ ] 삭제한 랠리의 페이지에 접속하면 404 오류 페이지가 나옵니다.

### 리뷰어에게

 #220 완료 후 리뷰 부탁드립니다. `app/(back)/kits/[id]/@modal/(.)delete/actions.ts` 와 관련 파일 위주로 리뷰 부탁드립니다.

### 체크리스트

- [ ] 리뷰하는데 20분 이상 필요한가요? _20분 초과할 경우, 예상 리뷰 시간을 덧붙여주세요_
- [x] 셀프 리뷰를 진행했습니다.
- [x] 커밋 메세지를 컨벤션에 맞게 작성했습니다.
- [x] 테스트 내용에 기재된 항목에 대해서 실제로 테스트를 진행하고 동작을 확인했습니다.
